### PR TITLE
Initialize camera on boot

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -32,6 +32,9 @@ function BootUI.init(config)
 
         local camerasFolder = Workspace:WaitForChild("Cameras", 5)
         local startPos = camerasFolder and camerasFolder:FindFirstChild("startPos")
+        if not startPos then
+                warn("BootUI: expected Workspace.Cameras.startPos to exist")
+        end
 
         local gui = Instance.new("ScreenGui")
         gui.ResetOnSpawn = false

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua.lua
@@ -17,6 +17,14 @@ local TeleportClient = require(ReplicatedStorage:WaitForChild("ClientModules"):W
 
 -- Initialize sequence: UI -> currency -> shop -> teleport -> cosmetics
 local ui = BootUI.init(GameSettings)
+
+-- Align the player's camera with the configured start position.
+-- BootUI exposes helpers for this; we use holdStartCam here so the
+-- camera immediately snaps to the startPos and stays there briefly.
+-- Alternatively, developers can swap this for ui.tweenToStart() to
+-- smoothly move the camera instead of snapping.
+ui.holdStartCam(3)
+
 local currency = CurrencyService.new(GameSettings)
 local shop = Shop.new(GameSettings, currency)
 ShopUI.init(GameSettings, shop, ui)


### PR DESCRIPTION
## Summary
- ensure boot script aligns the camera using BootUI's helpers
- warn if the expected `startPos` camera part is missing

## Testing
- `luacheck . | tail -n 20` (fails: 215 warnings / 5 errors)


------
https://chatgpt.com/codex/tasks/task_e_68bb96cf62d88332b11c474753767dd9