### PR TITLE
Add TeleportClient init and safer boot require

### DIFF
--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -87,4 +87,22 @@ function TeleportClient.bindWorldButtons(gui)
 	end
 end
 
+function TeleportClient.init(_config)
+        local playerGui = player:FindFirstChild("PlayerGui")
+        if not playerGui then
+                warn("TeleportClient: PlayerGui not found for " .. player.Name)
+                return
+        end
+
+        local teleGui = playerGui:WaitForChild("TeleportGui", 5)
+        if not teleGui then
+                warn("TeleportClient: TeleportGui not found")
+                return
+        end
+
+        local gui = { ScreenGui = teleGui }
+        TeleportClient.bindZoneButtons(gui)
+        TeleportClient.bindWorldButtons(gui)
+end
+
 return TeleportClient

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua.lua
@@ -13,7 +13,13 @@ local ShopUI = require(BootModules:WaitForChild("ShopUI"))
 local Cosmetics = require(BootModules:WaitForChild("Cosmetics"))
 
 -- Existing TeleportClient module kept in ClientModules
-local TeleportClient = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("TeleportClient"))
+local successTeleport, TeleportClient = pcall(function()
+        return require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("TeleportClient"))
+end)
+if not successTeleport then
+        warn("TeleportClient failed to load: " .. tostring(TeleportClient))
+        TeleportClient = nil
+end
 
 -- Initialize sequence: UI -> currency -> shop -> teleport -> cosmetics
 local ui = BootUI.init(GameSettings)
@@ -29,5 +35,7 @@ local currency = CurrencyService.new(GameSettings)
 local shop = Shop.new(GameSettings, currency)
 ShopUI.init(GameSettings, shop, ui)
 
-TeleportClient.init(GameSettings)
+if TeleportClient and TeleportClient.init then
+        TeleportClient.init(GameSettings)
+end
 Cosmetics.init(GameSettings)


### PR DESCRIPTION
## Summary
- add initialization helper for TeleportClient module
- guard Boot.client to require TeleportClient safely and only init when available

## Testing
- `luacheck ReplicatedStorage/ClientModules/TeleportClient.lua StarterPlayer/StarterPlayerScripts/Boot.client.lua.lua`

------
https://chatgpt.com/codex/tasks/task_e_68bba0bd21e4833282451ed6a81b1583