### PR TITLE
Initialize teleport UI and client

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -60,6 +60,43 @@ function BootUI.init(config)
         title.BackgroundTransparency = 1
         title.Parent = root
 
+        -- Teleport GUI with zone and world frames
+        local teleportGui = Instance.new("ScreenGui")
+        teleportGui.ResetOnSpawn = false
+        teleportGui.IgnoreGuiInset = true
+        teleportGui.Name = "TeleportGui"
+        teleportGui.Parent = player:WaitForChild("PlayerGui")
+
+        local teleFrame = Instance.new("Frame")
+        teleFrame.Name = "TeleFrame"
+        teleFrame.BackgroundTransparency = 1
+        teleFrame.Size = UDim2.fromScale(1,1)
+        teleFrame.Parent = teleportGui
+
+        local worldFrame = Instance.new("Frame")
+        worldFrame.Name = "WorldTeleFrame"
+        worldFrame.BackgroundTransparency = 1
+        worldFrame.Size = UDim2.fromScale(1,1)
+        worldFrame.Parent = teleportGui
+
+        local zoneNames = {"Atom","Fire","Grow","Ice","Light","Metal","Water","Wind","Dojo","Starter"}
+        for _, name in ipairs(zoneNames) do
+                local button = Instance.new("TextButton")
+                button.Name = name .. "Button"
+                button.Size = UDim2.fromOffset(100,50)
+                button.Text = name
+                button.Parent = teleFrame
+        end
+
+        local worldNames = {"Atom","Fire","Water"}
+        for _, name in ipairs(worldNames) do
+                local button = Instance.new("TextButton")
+                button.Name = name .. "Button"
+                button.Size = UDim2.fromOffset(100,50)
+                button.Text = name
+                button.Parent = worldFrame
+        end
+
         local function applyStartCam()
                 if not startPos then return end
                 cam.CameraType = Enum.CameraType.Scriptable
@@ -91,6 +128,7 @@ function BootUI.init(config)
         return {
                 gui = gui,
                 root = root,
+                teleportGui = teleportGui,
                 holdStartCam = holdStartCam,
                 tweenToStart = tweenToStart
         }

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -29,5 +29,5 @@ local currency = CurrencyService.new(GameSettings)
 local shop = Shop.new(GameSettings, currency)
 ShopUI.init(GameSettings, shop, ui)
 
-TeleportClient.init(ui)
+TeleportClient.init(ui.teleportGui)
 Cosmetics.init(GameSettings)

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -10,7 +10,6 @@ local AudioPlayer = require(ReplicatedStorage:WaitForChild("ClientModules"):Wait
 local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
 local CombatController = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CombatController"))
 local MerchBooth = require(ReplicatedStorage:WaitForChild("MerchBooth"))
-local TeleportClient = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("TeleportClient"))
 local GameSettings = require(ReplicatedStorage:WaitForChild("GameSettings"))
 
 local player = Players.LocalPlayer
@@ -146,10 +145,6 @@ UserInputService.InputBegan:Connect(function(input, gameProcessed)
 
 	print("? Key pressed but no action mapped:", input.KeyCode.Name)
 end)
-
--- Teleport setup
-TeleportClient.bindZoneButtons(PlayerGui)
-TeleportClient.bindWorldButtons(PlayerGui)
 
 -- Extended Slide behavior (1.5s duration, increased movement)
 CombatController.setSlideDuration(1.5)


### PR DESCRIPTION
## Summary
- build a TeleportGui during boot with TeleFrame and WorldTeleFrame buttons
- initialize TeleportClient using the TeleportGui created in BootUI
- drop redundant TeleportClient bindings from MainLocalScript

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua`
- `luac -p StarterPlayer/StarterPlayerScripts/Boot.client.lua`
- `luac -p StarterPlayer/StarterPlayerScripts/MainLocalScript.lua` *(fails: ')' expected near ':' due to typed Luau syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5c4a1fb8833288a769e45092d5f1