### PR TITLE
Initialize coins and disable unaffordable shop purchases

### DIFF
--- a/ReplicatedStorage/BootModules/CurrencyService.lua
+++ b/ReplicatedStorage/BootModules/CurrencyService.lua
@@ -7,12 +7,16 @@ function CurrencyService.new(config)
         self.coins = config.startCoins or 0
         self.orbs = config.startOrbs or 0
 
+        self.BalanceChanged = Instance.new("BindableEvent")
+        self.BalanceChanged:Fire(self.coins, self.orbs)
+
         local ReplicatedStorage = game:GetService("ReplicatedStorage")
         self.updateEvent = ReplicatedStorage:FindFirstChild("CurrencyUpdated")
         if self.updateEvent then
                 self.updateEvent.OnClientEvent:Connect(function(data)
                         if data.coins then self.coins = data.coins end
                         if data.orbs then self.orbs = data.orbs end
+                        self.BalanceChanged:Fire(self.coins, self.orbs)
                 end)
         end
 
@@ -28,6 +32,7 @@ function CurrencyService:AddCoins(amount)
         if self.updateEvent then
                 self.updateEvent:FireServer({coins = self.coins})
         end
+        self.BalanceChanged:Fire(self.coins, self.orbs)
 end
 
 function CurrencyService:SpendCoins(amount)
@@ -36,6 +41,7 @@ function CurrencyService:SpendCoins(amount)
         if self.updateEvent then
                 self.updateEvent:FireServer({coins = self.coins})
         end
+        self.BalanceChanged:Fire(self.coins, self.orbs)
         return true
 end
 

--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -11,14 +11,31 @@ function ShopUI.init(config, shop, bootUI)
         frame.BackgroundColor3 = Color3.fromRGB(40,40,42)
         frame.Parent = root
 
+        local cost = 10
+
         local buy = Instance.new("TextButton")
         buy.Size = UDim2.fromScale(1,0.3)
         buy.Position = UDim2.fromScale(0,0.7)
         buy.Text = "Buy Sample Item"
         buy.Parent = frame
 
+        local currencyService = shop and shop.currencyService
+        local function updateButton(coins)
+                coins = coins or (currencyService and currencyService:GetBalance() or 0)
+                local canAfford = coins >= cost
+                buy.Active = canAfford
+                buy.AutoButtonColor = canAfford
+                buy.TextTransparency = canAfford and 0 or 0.5
+        end
+        updateButton()
+        if currencyService and currencyService.BalanceChanged then
+                currencyService.BalanceChanged.Event:Connect(function(c)
+                        updateButton(c)
+                end)
+        end
+
         buy.Activated:Connect(function()
-                shop:Purchase("Sample", 10)
+                shop:Purchase("Sample", cost)
         end)
 end
 

--- a/ReplicatedStorage/GameSettings.lua
+++ b/ReplicatedStorage/GameSettings.lua
@@ -18,6 +18,7 @@ GameSettings.levelUpMessage = "You Leveled Up!"
 -- Starting data values
 GameSettings.startUpgrades = 1
 GameSettings.startPoints = 0
+GameSettings.startCoins = 100
 
 GameSettings.pointsName = "Points"
 GameSettings.upgradeName = "Upgrades"


### PR DESCRIPTION
## Summary
- give players 100 starting coins for testing
- broadcast balance changes from CurrencyService
- disable shop button until the player can afford the item

## Testing
- `luac -p ReplicatedStorage/GameSettings.lua ReplicatedStorage/BootModules/CurrencyService.lua ReplicatedStorage/BootModules/ShopUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_68bc63d95db48332b7c6d51c9bf669a3