### PR TITLE
Use Cosmetics ModuleScript from ReplicatedStorage BootModules

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -10,7 +10,7 @@ local BootUI = require(BootModules:WaitForChild("BootUI"))
 local CurrencyService = require(BootModules:WaitForChild("CurrencyService"))
 local Shop = require(BootModules:WaitForChild("Shop"))
 local ShopUI = require(BootModules:WaitForChild("ShopUI"))
-local Cosmetics = require(BootModules:WaitForChild("Cosmetics"))
+local Cosmetics = require(ReplicatedStorage.BootModules.Cosmetics)
 
 -- TeleportClient centralizes teleport button wiring
 local TeleportClient = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("TeleportClient"))


### PR DESCRIPTION
## Summary
- Load Cosmetics module from `ReplicatedStorage.BootModules` in boot script
- Confirm no leftover Cosmetics LocalScripts under StarterPlayerScripts

## Testing
- `luac -p StarterPlayer/StarterPlayerScripts/Boot.client.lua`
- `luac -p ReplicatedStorage/BootModules/Cosmetics.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bcd0674bf8833287462742ee932a32