### PR TITLE
Use pairs() for TeleportClient spawn loops

### DIFF
--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -68,7 +68,7 @@ function TeleportClient.bindZoneButtons(gui)
                 Starter = {"ZoneStarter", "StarterZoneSpawnLocation"}
         }
 
-        for name, zoneInfo in islandSpawns do
+        for name, zoneInfo in pairs(islandSpawns) do
                 local button = teleFrame:FindFirstChild(name .. "Button")
                 if button then
                         button.Activated:Connect(function()
@@ -99,7 +99,7 @@ function TeleportClient.bindWorldButtons(gui)
                 Water = 15999399322
         }
 
-        for name, placeId in worldSpawnIds do
+        for name, placeId in pairs(worldSpawnIds) do
                 local button = worldFrame:FindFirstChild(name .. "Button")
                 if button then
                         button.Activated:Connect(function()


### PR DESCRIPTION
## Summary
- use `pairs` when iterating teleport destinations to ensure buttons bind correctly

## Testing
- `lua test_teleportclient.lua` *(stubbed Roblox services to run TeleportClient.init)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf175041c833282c4d039ef4db636