### PR TITLE
Handle frame roots in TeleportClient bindings

### DIFF
--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -43,13 +43,12 @@ local function teleportToPlace(placeId)
 end
 
 function TeleportClient.bindZoneButtons(gui)
-        local screenGui = (gui and (gui.ScreenGui or gui.gui)) or gui
-        if not screenGui then
-                warn("TeleportClient: ScreenGui missing for zone buttons")
+        if not gui then
+                warn("TeleportClient: gui parameter missing for zone buttons")
                 return
         end
 
-        local teleFrame = screenGui:FindFirstChild("TeleFrame")
+        local teleFrame = gui:FindFirstChild("TeleFrame", true)
         if not teleFrame then
                 warn("TeleportClient: TeleFrame not found")
                 return
@@ -68,7 +67,7 @@ function TeleportClient.bindZoneButtons(gui)
                 Starter = {"ZoneStarter", "StarterZoneSpawnLocation"}
         }
 
-        for name, zoneInfo in islandSpawns do
+        for name, zoneInfo in pairs(islandSpawns) do
                 local button = teleFrame:FindFirstChild(name .. "Button")
                 if button then
                         button.Activated:Connect(function()
@@ -81,13 +80,12 @@ function TeleportClient.bindZoneButtons(gui)
 end
 
 function TeleportClient.bindWorldButtons(gui)
-        local screenGui = (gui and (gui.ScreenGui or gui.gui)) or gui
-        if not screenGui then
-                warn("TeleportClient: ScreenGui missing for world buttons")
+        if not gui then
+                warn("TeleportClient: gui parameter missing for world buttons")
                 return
         end
 
-        local worldFrame = screenGui:FindFirstChild("WorldTeleFrame")
+        local worldFrame = gui:FindFirstChild("WorldTeleFrame", true)
         if not worldFrame then
                 warn("TeleportClient: WorldTeleFrame not found")
                 return
@@ -99,7 +97,7 @@ function TeleportClient.bindWorldButtons(gui)
                 Water = 15999399322
         }
 
-        for name, placeId in worldSpawnIds do
+        for name, placeId in pairs(worldSpawnIds) do
                 local button = worldFrame:FindFirstChild(name .. "Button")
                 if button then
                         button.Activated:Connect(function()


### PR DESCRIPTION
## Summary
- search provided GUI for `TeleFrame` and `WorldTeleFrame` instead of assuming a `ScreenGui` ancestor

## Testing
- `lua - <<'EOF' ... EOF` (binding test confirms Dojo and world buttons connect without runtime errors)


------
https://chatgpt.com/codex/tasks/task_e_68bcf175041c833282c4d039ef4db636