### PR TITLE
Add toggleable shop UI

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -2,6 +2,7 @@ local BootUI = {}
 
 function BootUI.start(config)
     config = config or {}
+    config.showShop = config.showShop or false
     BootUI.config = config
 -- Ninja World EXP 3000
 -- Boot.client.lua – v7.4
@@ -155,7 +156,29 @@ root.Parent = ui
 
 BootUI.root = root
 Cosmetics.init(config, root, BootUI)
-ShopUI.init(config, shop, BootUI)
+local function toggleShop()
+    if not BootUI.shopFrame then
+        BootUI.shopFrame = ShopUI.init(config, shop, BootUI)
+    else
+        BootUI.shopFrame.Visible = not BootUI.shopFrame.Visible
+    end
+end
+BootUI.toggleShop = toggleShop
+if config.showShop then
+    toggleShop()
+end
+local shopBtn = Instance.new("TextButton")
+shopBtn.Size = UDim2.fromOffset(120,40)
+shopBtn.Position = UDim2.fromOffset(20,20)
+shopBtn.Text = "Shop"
+shopBtn.Font = Enum.Font.GothamSemibold
+shopBtn.TextScaled = true
+shopBtn.TextColor3 = Color3.new(1,1,1)
+shopBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
+shopBtn.AutoButtonColor = true
+shopBtn.ZIndex = 10
+shopBtn.Parent = root
+shopBtn.Activated:Connect(toggleShop)
 TeleportClient.init(root)
 
 -- Intro visuals

--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -37,6 +37,7 @@ function ShopUI.init(config, shop, bootUI)
         buy.Activated:Connect(function()
                 shop:Purchase("Sample", cost)
         end)
+        return frame
 end
 
 return ShopUI


### PR DESCRIPTION
## Summary
- make shop UI optional via `config.showShop`
- add `BootUI.toggleShop` and a button to show or hide the shop
- return shop frame from `ShopUI.init` for visibility control

## Testing
- ⚠️ `luac -p ReplicatedStorage/BootModules/BootUI.lua` (unsupported `+=` Luau syntax)
- ✅ `luac -p ReplicatedStorage/BootModules/ShopUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bcf8f4f36c8332906494705af1adec