### PR TITLE
Parameterize backpack and sync currency

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -56,11 +56,9 @@ local ASSETS = {
     PaperTex = "rbxassetid://131504699316598",
 }
 
-local StarterBackpack = {
+local StarterBackpack = config.starterBackpack or {
     capacity = 20,
-    items = {
-        {name = "Elemental Orbs", qty = 3, stack = 9},
-    }
+    items = {}
 }
 BootUI.StarterBackpack = StarterBackpack
 

--- a/ReplicatedStorage/BootModules/CurrencyService.lua
+++ b/ReplicatedStorage/BootModules/CurrencyService.lua
@@ -3,24 +3,25 @@ CurrencyService.__index = CurrencyService
 
 -- Simple currency tracker with client/server sync.
 function CurrencyService.new(config)
-        local self = setmetatable({}, CurrencyService)
-        self.coins = config.startCoins or 0
-        self.orbs = config.startOrbs or 0
+    local self = setmetatable({}, CurrencyService)
+    self.coins = 0
+    self.orbs = 0
 
-        self.BalanceChanged = Instance.new("BindableEvent")
-        self.BalanceChanged:Fire(self.coins, self.orbs)
+    self.BalanceChanged = Instance.new("BindableEvent")
+    self.BalanceChanged:Fire(self.coins, self.orbs)
 
-        local ReplicatedStorage = game:GetService("ReplicatedStorage")
-        self.updateEvent = ReplicatedStorage:FindFirstChild("CurrencyUpdated")
-        if self.updateEvent then
-                self.updateEvent.OnClientEvent:Connect(function(data)
-                        if data.coins then self.coins = data.coins end
-                        if data.orbs then self.orbs = data.orbs end
-                        self.BalanceChanged:Fire(self.coins, self.orbs)
-                end)
-        end
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    self.updateEvent = ReplicatedStorage:FindFirstChild("CurrencyUpdated")
+    if self.updateEvent then
+        self.updateEvent.OnClientEvent:Connect(function(data)
+            if data.coins then self.coins = data.coins end
+            if data.orbs then self.orbs = data.orbs end
+            self.BalanceChanged:Fire(self.coins, self.orbs)
+        end)
+        self.updateEvent:FireServer({request = true})
+    end
 
-        return self
+    return self
 end
 
 function CurrencyService:GetBalance()

--- a/ServerScriptService/CurrencyService.server.lua
+++ b/ServerScriptService/CurrencyService.server.lua
@@ -1,0 +1,40 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local updateEvent = ReplicatedStorage:FindFirstChild("CurrencyUpdated")
+if not updateEvent then
+    updateEvent = Instance.new("RemoteEvent")
+    updateEvent.Name = "CurrencyUpdated"
+    updateEvent.Parent = ReplicatedStorage
+end
+
+local balances = {}
+
+local function sendBalance(player)
+    local data = balances[player.UserId]
+    if data then
+        updateEvent:FireClient(player, data)
+    end
+end
+
+Players.PlayerAdded:Connect(function(player)
+    balances[player.UserId] = {coins = 0, orbs = 0}
+end)
+
+Players.PlayerRemoving:Connect(function(player)
+    balances[player.UserId] = nil
+end)
+
+updateEvent.OnServerEvent:Connect(function(player, data)
+    local balance = balances[player.UserId]
+    if not balance then
+        balance = {coins = 0, orbs = 0}
+        balances[player.UserId] = balance
+    end
+    if typeof(data) == "table" then
+        if data.coins then balance.coins = data.coins end
+        if data.orbs then balance.orbs = data.orbs end
+    end
+    sendBalance(player)
+end)
+


### PR DESCRIPTION
## Summary
- Make starter backpack configurable and remove hard-coded "Elemental Orbs"
- Initialize CurrencyService balances at zero and request server sync
- Track currency on the server to persist player balances

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua` *(fails: '=' expected near '+')*
- `luac -p ReplicatedStorage/BootModules/CurrencyService.lua`
- `luac -p ServerScriptService/CurrencyService.server.lua && echo "OK"`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa58d2fc8332a6f5e39044cc22b0