### PR TITLE
Add clear persona slot functionality with confirmation

### DIFF
--- a/ServerScriptService/PersonaService.server.lua
+++ b/ServerScriptService/PersonaService.server.lua
@@ -118,15 +118,22 @@ rf.OnServerInvoke = function(player, action, data)
 		local ok = safeSet(key, personas)
 		return {ok=ok, slots = personas}
 
-	elseif action == "use" then
-		local s = data and tonumber(data.slot)
+        elseif action == "use" then
+                local s = data and tonumber(data.slot)
                 if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
-		local p = personas[s]
-		if not p then return {ok=false, err="empty slot"} end
+                local p = personas[s]
+                if not p then return {ok=false, err="empty slot"} end
 
-		player:SetAttribute("PersonaType", p.type)
-		return {ok=true, persona=p}
-	end
+                player:SetAttribute("PersonaType", p.type)
+                return {ok=true, persona=p}
+
+        elseif action == "clear" then
+                local s = data and tonumber(data.slot)
+                if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
+                personas[s] = nil
+                local ok = safeSet(key, personas)
+                return {ok=ok, slots=personas}
+        end
 
 	return {ok=false, err="unknown action"}
 end


### PR DESCRIPTION
## Summary
- add Clear button to each persona slot row with confirmation dialog
- implement server-side `clear` action to delete saved persona slots

## Testing
- `luac -p ReplicatedStorage/BootModules/Cosmetics.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bcffbd30088332ad2db2e7ea71d0af