### PR TITLE
Add ability unlocking system and purchase interface

### DIFF
--- a/ReplicatedStorage/BootModules/AbilityUI.lua
+++ b/ReplicatedStorage/BootModules/AbilityUI.lua
@@ -1,0 +1,35 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+
+local AbilityUI = {}
+
+function AbilityUI.init(config, bootUI)
+    local root = bootUI and bootUI.root
+    if not root then return end
+
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(0.3,0.4)
+    frame.Position = UDim2.fromScale(0.35,0.3)
+    frame.BackgroundColor3 = Color3.fromRGB(40,40,42)
+    frame.Visible = true
+    frame.Parent = root
+
+    local layout = Instance.new("UIListLayout")
+    layout.Parent = frame
+
+    local learnRF = ReplicatedStorage:WaitForChild("LearnAbility")
+
+    for ability, info in pairs(AbilityMetadata) do
+        local btn = Instance.new("TextButton")
+        btn.Size = UDim2.new(1,0,0,40)
+        btn.Text = ability .. " (" .. info.cost .. " Coins)"
+        btn.Parent = frame
+        btn.Activated:Connect(function()
+            learnRF:InvokeServer(ability)
+        end)
+    end
+
+    return frame
+end
+
+return AbilityUI

--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -35,6 +35,7 @@ local Cosmetics       = require(ReplicatedStorage.BootModules.Cosmetics)
 local CurrencyService = require(ReplicatedStorage.BootModules.CurrencyService)
 local Shop            = require(ReplicatedStorage.BootModules.Shop)
 local ShopUI          = require(ReplicatedStorage.BootModules.ShopUI)
+local AbilityUI       = require(ReplicatedStorage.BootModules.AbilityUI)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
 
 -- =====================
@@ -165,6 +166,16 @@ BootUI.toggleShop = toggleShop
 if config.showShop then
     toggleShop()
 end
+
+local abilityFrame
+local function toggleAbilities()
+    if not abilityFrame then
+        abilityFrame = AbilityUI.init(config, BootUI)
+    else
+        abilityFrame.Visible = not abilityFrame.Visible
+    end
+end
+BootUI.toggleAbilities = toggleAbilities
 local shopBtn = Instance.new("TextButton")
 shopBtn.Size = UDim2.fromOffset(120,40)
 shopBtn.Position = UDim2.fromOffset(20,20)
@@ -177,6 +188,19 @@ shopBtn.AutoButtonColor = true
 shopBtn.ZIndex = 10
 shopBtn.Parent = root
 shopBtn.Activated:Connect(toggleShop)
+
+local abilityBtn = Instance.new("TextButton")
+abilityBtn.Size = UDim2.fromOffset(120,40)
+abilityBtn.Position = UDim2.fromOffset(150,20)
+abilityBtn.Text = "Abilities"
+abilityBtn.Font = Enum.Font.GothamSemibold
+abilityBtn.TextScaled = true
+abilityBtn.TextColor3 = Color3.new(1,1,1)
+abilityBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
+abilityBtn.AutoButtonColor = true
+abilityBtn.ZIndex = 10
+abilityBtn.Parent = root
+abilityBtn.Activated:Connect(toggleAbilities)
 TeleportClient.init(root)
 
 -- Intro visuals

--- a/ReplicatedStorage/ClientModules/Abilities.lua
+++ b/ReplicatedStorage/ClientModules/Abilities.lua
@@ -1,10 +1,41 @@
 -- Abilities Module
+local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
 
 local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
+local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
 
 local Abilities = {}
+local unlocked = {}
+Abilities.unlocked = unlocked
+
+local player = Players.LocalPlayer
+local abilitiesFolder = player:WaitForChild("Abilities", 5)
+if abilitiesFolder then
+        for _, child in ipairs(abilitiesFolder:GetChildren()) do
+                if child:IsA("BoolValue") and child.Value then
+                        unlocked[child.Name] = true
+                end
+        end
+        abilitiesFolder.ChildAdded:Connect(function(child)
+                if child:IsA("BoolValue") and child.Value then
+                        unlocked[child.Name] = true
+                end
+        end)
+end
+
+function Abilities.isUnlocked(name)
+        return unlocked[name]
+end
+
+local function ensureUnlocked(name)
+        if not unlocked[name] then
+                warn("Ability " .. name .. " is locked")
+                return false
+        end
+        return true
+end
 
 -- FX templates
 local function createOrb()
@@ -35,7 +66,8 @@ local function createOrb()
 end
 
 function Abilities.Toss()
-	local animator = CharacterManager.animator
+        if not ensureUnlocked("Toss") then return end
+        local animator = CharacterManager.animator
 	if not animator then return end
 
 	local tossAnimation = Instance.new("Animation")
@@ -53,9 +85,10 @@ function Abilities.Toss()
 end
 
 function Abilities.Star()
-	local animator = CharacterManager.animator
+        if not ensureUnlocked("Star") then return end
+        local animator = CharacterManager.animator
 	if not animator or not CharacterManager.starModel then
-		warn("?? Star ability failed – missing animator or starModel")
+		warn("?? Star ability failed Â– missing animator or starModel")
 		return
 	end
 
@@ -83,7 +116,8 @@ function Abilities.Star()
 end
 
 function Abilities.Rain()
-	local offset = Vector3.new(0, 12, 0)
+        if not ensureUnlocked("Rain") then return end
+        local offset = Vector3.new(0, 12, 0)
 	local caster = CharacterManager.character
 	local humanoidRoot = CharacterManager.humanoidRoot
 	local rainTemplate = ReplicatedStorage:WaitForChild("Elements"):WaitForChild("WaterElem"):FindFirstChild("WaterRain")
@@ -126,7 +160,13 @@ function Abilities.Rain()
 	end
 end
 
-function Abilities.Dragon() warn("?? Dragon not implemented yet") end
-function Abilities.Beast() warn("?? Beast not implemented yet") end
+function Abilities.Dragon()
+        if not ensureUnlocked("Dragon") then return end
+        warn("?? Dragon not implemented yet")
+end
+function Abilities.Beast()
+        if not ensureUnlocked("Beast") then return end
+        warn("?? Beast not implemented yet")
+end
 
 return Abilities

--- a/ReplicatedStorage/ClientModules/AbilityMetadata.lua
+++ b/ReplicatedStorage/ClientModules/AbilityMetadata.lua
@@ -1,0 +1,9 @@
+local AbilityMetadata = {
+    Toss = {cost = 50, prerequisites = {}},
+    Star = {cost = 100, prerequisites = {"Toss"}},
+    Rain = {cost = 200, prerequisites = {"Star"}},
+    Dragon = {cost = 300, prerequisites = {"Rain"}},
+    Beast = {cost = 300, prerequisites = {"Rain"}},
+}
+
+return AbilityMetadata

--- a/ReplicatedStorage/ClientModules/CombatController.lua
+++ b/ReplicatedStorage/ClientModules/CombatController.lua
@@ -57,13 +57,18 @@ function CombatController.getTracks()
 end
 
 function CombatController.perform(actionName)
-	print("Performing action:", actionName)
-        if actionName == "Rain" then
-                Abilities.Rain()
+        print("Performing action:", actionName)
+        local abilityFunc = Abilities[actionName]
+        if type(abilityFunc) == "function" then
+                if Abilities.isUnlocked(actionName) then
+                        abilityFunc()
+                else
+                        warn("Ability " .. actionName .. " is locked")
+                end
                 return
         end
-	if actionName == "Crouch" then
-		local track = animationTracks["Crch"]
+        if actionName == "Crouch" then
+                local track = animationTracks["Crch"]
 		if track then
 			if CharacterManager.isCrouching then
 				track:AdjustSpeed(1)

--- a/ServerScriptService/AbilityService.server.lua
+++ b/ServerScriptService/AbilityService.server.lua
@@ -1,0 +1,45 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+
+local learnRF = Instance.new("RemoteFunction")
+learnRF.Name = "LearnAbility"
+learnRF.Parent = ReplicatedStorage
+
+local function prerequisitesMet(player, abilityName)
+    local info = AbilityMetadata[abilityName]
+    if not info then return false end
+    local abilitiesFolder = player:FindFirstChild("Abilities")
+    for _, prereq in ipairs(info.prerequisites or {}) do
+        if not (abilitiesFolder and abilitiesFolder:FindFirstChild(prereq)) then
+            return false
+        end
+    end
+    return true
+end
+
+learnRF.OnServerInvoke = function(player, abilityName)
+    local info = AbilityMetadata[abilityName]
+    if not info then
+        return false, "Unknown ability"
+    end
+    local abilitiesFolder = player:FindFirstChild("Abilities")
+    if abilitiesFolder and abilitiesFolder:FindFirstChild(abilityName) then
+        return true
+    end
+    if not prerequisitesMet(player, abilityName) then
+        return false, "Missing prerequisites"
+    end
+    local coins = player:FindFirstChild("leaderstats") and player.leaderstats:FindFirstChild("Coins")
+    if not coins or coins.Value < info.cost then
+        return false, "Not enough currency"
+    end
+    coins.Value -= info.cost
+    abilitiesFolder = abilitiesFolder or Instance.new("Folder")
+    abilitiesFolder.Name = "Abilities"
+    abilitiesFolder.Parent = player
+    local owned = Instance.new("BoolValue")
+    owned.Name = abilityName
+    owned.Value = true
+    owned.Parent = abilitiesFolder
+    return true
+end


### PR DESCRIPTION
## Summary
- define ability metadata with costs and prerequisites
- gate ability execution on an unlocked table and expose unlock toggling
- add server API and UI to purchase abilities with currency

## Testing
- `luacheck ReplicatedStorage/ClientModules/Abilities.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd01a6d4e483329bb63ba6ed06acf1