### PR TITLE
Track orbs per element and cap total

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -63,7 +63,7 @@ local StarterBackpack = config.starterBackpack or {
     food = {},
     special = {},
     coins = 0,
-    orbs = 0,
+    orbs = {},
 }
 BootUI.StarterBackpack = StarterBackpack
 
@@ -618,7 +618,17 @@ local function populateBackpackUI(bp)
     -- currency section
     addHeader("Currency")
     addSimpleRow("Coins", bp.coins or 0)
-    addSimpleRow("Orbs", bp.orbs or 0)
+
+    -- orbs section
+    local orbTable = bp.orbs or {}
+    local totalOrbs = 0
+    for _, v in pairs(orbTable) do totalOrbs += v end
+    addHeader(string.format("Orbs (%d / 10)", totalOrbs))
+    for element, v in pairs(orbTable) do
+        if v > 0 then
+            addSimpleRow(element, v)
+        end
+    end
 
     -- item sections
     local sections = {

--- a/ReplicatedStorage/BootModules/CurrencyService.lua
+++ b/ReplicatedStorage/BootModules/CurrencyService.lua
@@ -5,7 +5,7 @@ CurrencyService.__index = CurrencyService
 function CurrencyService.new(config)
     local self = setmetatable({}, CurrencyService)
     self.coins = 0
-    self.orbs = 0
+    self.orbs = {}
 
     self.BalanceChanged = Instance.new("BindableEvent")
     self.BalanceChanged:Fire(self.coins, self.orbs)
@@ -34,6 +34,26 @@ function CurrencyService:AddCoins(amount)
                 self.updateEvent:FireServer({coins = self.coins})
         end
         self.BalanceChanged:Fire(self.coins, self.orbs)
+end
+
+function CurrencyService:GetOrbCount()
+        local total = 0
+        for _, v in pairs(self.orbs) do
+                total += v
+        end
+        return total
+end
+
+function CurrencyService:AddOrb(element)
+        if typeof(element) ~= "string" then return false end
+        if self.orbs[element] then return false end
+        if self:GetOrbCount() >= 10 then return false end
+        self.orbs[element] = 1
+        if self.updateEvent then
+                self.updateEvent:FireServer({addOrb = element})
+        end
+        self.BalanceChanged:Fire(self.coins, self.orbs)
+        return true
 end
 
 function CurrencyService:SpendCoins(amount)

--- a/ServerScriptService/CurrencyService.server.lua
+++ b/ServerScriptService/CurrencyService.server.lua
@@ -8,7 +8,16 @@ if not updateEvent then
     updateEvent.Parent = ReplicatedStorage
 end
 
+local MAX_ORBS = 10
 local balances = {}
+
+local function getOrbCount(orbs)
+    local total = 0
+    for _, v in pairs(orbs) do
+        total += v
+    end
+    return total
+end
 
 local function sendBalance(player)
     local data = balances[player.UserId]
@@ -17,8 +26,32 @@ local function sendBalance(player)
     end
 end
 
+local function addOrb(player, element)
+    local balance = balances[player.UserId]
+    if not balance or typeof(element) ~= "string" then return end
+    balance.orbs = balance.orbs or {}
+    if balance.orbs[element] then return end
+    if getOrbCount(balance.orbs) >= MAX_ORBS then return end
+    balance.orbs[element] = 1
+
+    local inv = player:GetAttribute("Inventory")
+    if type(inv) ~= "table" then inv = {} end
+    inv.orbs = inv.orbs or {}
+    inv.orbs[element] = 1
+    player:SetAttribute("Inventory", inv)
+
+    sendBalance(player)
+end
+
 Players.PlayerAdded:Connect(function(player)
-    balances[player.UserId] = {coins = 0, orbs = 0}
+    balances[player.UserId] = {coins = 0, orbs = {}}
+    player:GetAttributeChangedSignal("Inventory"):Connect(function()
+        local inv = player:GetAttribute("Inventory")
+        if type(inv) == "table" and type(inv.orbs) == "table" then
+            balances[player.UserId].orbs = inv.orbs
+            sendBalance(player)
+        end
+    end)
 end)
 
 Players.PlayerRemoving:Connect(function(player)
@@ -28,12 +61,13 @@ end)
 updateEvent.OnServerEvent:Connect(function(player, data)
     local balance = balances[player.UserId]
     if not balance then
-        balance = {coins = 0, orbs = 0}
+        balance = {coins = 0, orbs = {}}
         balances[player.UserId] = balance
     end
     if typeof(data) == "table" then
         if data.coins then balance.coins = data.coins end
-        if data.orbs then balance.orbs = data.orbs end
+        if data.addOrb then addOrb(player, data.addOrb) return end
+        if data.request then sendBalance(player) return end
     end
     sendBalance(player)
 end)


### PR DESCRIPTION
## Summary
- Track orbs in player inventory by element and ensure the combined count never exceeds ten.
- Add `AddOrb` and `GetOrbCount` to CurrencyService on both client and server with validation to prevent duplicates and enforce the cap. Server updates replicate and persist through DataSavingScript.
- Expand BootUI to show an Orbs section listing owned elements and displaying total orb count.

## Testing
- `luac -p ServerScriptService/DataSavingScript.lua` *(failed: command not found)*
- `lua -v` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd0aecb1ac833298528045e18cef5d