### PR TITLE
Use IntValue for leaderboard coins and level

### DIFF
--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -141,7 +141,7 @@ local function playerAdded(player)
     leaderstats.Name = "leaderstats"
     leaderstats.Parent = player
 
-    local coinsValue = Instance.new("NumberValue")
+    local coinsValue = Instance.new("IntValue")
     coinsValue.Name = "Coins"
     coinsValue.Value = data.currency.Coins
     coinsValue.Parent = leaderstats
@@ -179,7 +179,7 @@ local function playerAdded(player)
         sessionData[player.UserId].kills = kills.Value
     end)
 
-    local leaderLevel = Instance.new("NumberValue")
+    local leaderLevel = Instance.new("IntValue")
     leaderLevel.Name = "Level"
     leaderLevel.Value = levelValue.Value
     leaderLevel.Parent = leaderstats


### PR DESCRIPTION
## Summary
- ensure leaderstats uses `IntValue` for Coins and Level

## Testing
- `python - <<'PY'
import re, pathlib, json
text = pathlib.Path('ServerScriptService/DataSavingScript.lua').read_text()
coins_line = re.search(r'local\s+coinsValue\s*=\s*Instance\.new\("([^"]+)"\)', text)
leader_line = re.search(r'local\s+leaderLevel\s*=\s*Instance\.new\("([^"]+)"\)', text)
print('coinsValue class:', coins_line.group(1) if coins_line else 'not found')
print('leaderLevel class:', leader_line.group(1) if leader_line else 'not found')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bd0e4a8ecc8332a2d6beb2546aa575