### PR TITLE
Preserve layout in backpack UI refresh

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -411,7 +411,11 @@ btnEnterMain.Visible = (MAIN_PLACE_ID and MAIN_PLACE_ID > 0)
 -- Helpers (UI logic)
 -- =====================
 local function clearChildren(p)
-    for _,c in ipairs(p:GetChildren()) do c:Destroy() end
+    for _, c in ipairs(p:GetChildren()) do
+        if not c:IsA("UIListLayout") then
+            c:Destroy()
+        end
+    end
 end
 
 -- Orbitable viewport state


### PR DESCRIPTION
## Summary
- Keep existing UIListLayout when clearing children so vertical spacing stays intact after refresh

## Testing
- `python - <<'PY'
class Instance:
    def __init__(self, className, parent=None):
        self.ClassName=className
        self.children=[]
        self.parent=parent
        if parent:
            parent.children.append(self)
    def IsA(self, cls):
        return self.ClassName==cls
    def Destroy(self):
        if self.parent:
            self.parent.children.remove(self)
        self.parent=None
    def GetChildren(self):
        return list(self.children)

# clearChildren function

def clearChildren(p):
    for c in p.GetChildren():
        if not c.IsA('UIListLayout'):
            c.Destroy()

# simulate list
lst=Instance('ScrollingFrame')
layout=Instance('UIListLayout', lst)
item=Instance('Frame', lst)
print('before', [c.ClassName for c in lst.GetChildren()])
clearChildren(lst)
print('after', [c.ClassName for c in lst.GetChildren()])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bd0e6805fc8332bd804d59b36a15f2