### PR TITLE
Hide menu buttons until loadout

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -191,6 +191,8 @@ shopBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
 shopBtn.AutoButtonColor = true
 shopBtn.ZIndex = 10
 shopBtn.Parent = root
+shopBtn.Visible = false
+BootUI.shopBtn = shopBtn
 shopBtn.Activated:Connect(toggleShop)
 
 local abilityBtn = Instance.new("TextButton")
@@ -204,6 +206,8 @@ abilityBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
 abilityBtn.AutoButtonColor = true
 abilityBtn.ZIndex = 10
 abilityBtn.Parent = root
+abilityBtn.Visible = false
+BootUI.abilityBtn = abilityBtn
 abilityBtn.Activated:Connect(toggleAbilities)
 TeleportClient.init(root)
 
@@ -277,9 +281,10 @@ BootUI.loadout = loadout
 
 local loadTitle = Instance.new("TextLabel")
 loadTitle.Size = UDim2.new(1,-40,0,60)
-loadTitle.Position = UDim2.fromOffset(20,20)
+loadTitle.Position = UDim2.new(0.5,0,0,20)
+loadTitle.AnchorPoint = Vector2.new(0.5,0)
 loadTitle.BackgroundTransparency = 0.6
-loadTitle.TextXAlignment = Enum.TextXAlignment.Left
+loadTitle.TextXAlignment = Enum.TextXAlignment.Center
 loadTitle.Text = "Loadout"
 loadTitle.Font = Enum.Font.GothamBold
 loadTitle.TextScaled = true

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -36,28 +36,36 @@ end
 
 local function showDojoPicker()
     if dojo then dojo.Visible = true end
-    if boot and boot.loadout then boot.loadout.Visible = false end
+    if boot then
+        if boot.loadout then boot.loadout.Visible = false end
+        if boot.shopBtn then boot.shopBtn.Visible = false end
+        if boot.abilityBtn then boot.abilityBtn.Visible = false end
+    end
 end
 
 local function showLoadout(personaType)
     if dojo then dojo.Visible = false end
-    if boot and boot.loadout then
-        boot.loadout.Visible = true
-        if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
-        if boot.populateBackpackUI then
-            local saved = player:GetAttribute("Inventory")
-            if saved then
-                boot.populateBackpackUI(saved)
-            elseif boot.StarterBackpack then
-                boot.populateBackpackUI(boot.StarterBackpack)
-                local conn
-                conn = player:GetAttributeChangedSignal("Inventory"):Connect(function()
-                    local inv = player:GetAttribute("Inventory")
-                    if inv then
-                        boot.populateBackpackUI(inv)
-                        conn:Disconnect()
-                    end
-                end)
+    if boot then
+        if boot.shopBtn then boot.shopBtn.Visible = true end
+        if boot.abilityBtn then boot.abilityBtn.Visible = true end
+        if boot.loadout then
+            boot.loadout.Visible = true
+            if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
+            if boot.populateBackpackUI then
+                local saved = player:GetAttribute("Inventory")
+                if saved then
+                    boot.populateBackpackUI(saved)
+                elseif boot.StarterBackpack then
+                    boot.populateBackpackUI(boot.StarterBackpack)
+                    local conn
+                    conn = player:GetAttributeChangedSignal("Inventory"):Connect(function()
+                        local inv = player:GetAttribute("Inventory")
+                        if inv then
+                            boot.populateBackpackUI(inv)
+                            conn:Disconnect()
+                        end
+                    end)
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- Hide Shop and Abilities buttons until the loadout screen
- Center the Loadout title in the loadout screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd12612eb08332bf538414e29e6d25