### PR TITLE
Enlarge dojo logo and reposition persona slots

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -224,7 +224,7 @@ paperBG.ZIndex = 1
 paperBG.Parent = root
 
 local logoImg = Instance.new("ImageLabel")
-logoImg.Size = UDim2.fromOffset(300,300)
+logoImg.Size = UDim2.fromOffset(900,900)
 logoImg.Position = UDim2.fromScale(0.5,0.25)
 logoImg.AnchorPoint = Vector2.new(0.5,0.5)
 logoImg.BackgroundTransparency = 1

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -244,23 +244,10 @@ function Cosmetics.init(config, root, bootUI)
     line.ZIndex = 11
     line.Parent = picker
 
-    local slotsTitle = Instance.new("TextLabel")
-    slotsTitle.Size = UDim2.new(0.9,0,0,32)
-    -- Lift persona slot title to reduce empty space below the dojo title
-    slotsTitle.Position = UDim2.fromScale(0.5,0.3)
-    slotsTitle.AnchorPoint = Vector2.new(0.5,0.5)
-    slotsTitle.Text = "Persona Slots"
-    slotsTitle.Font = Enum.Font.GothamSemibold
-    slotsTitle.TextScaled = true
-    slotsTitle.TextColor3 = Color3.fromRGB(230,230,230)
-    slotsTitle.BackgroundTransparency = 1
-    slotsTitle.ZIndex = 11
-    slotsTitle.Parent = picker
-
+    -- Display persona slots directly beneath the dojo logo
     local slotsFrame = Instance.new("ScrollingFrame")
     slotsFrame.Size = UDim2.new(0.9,0,0.55,0)
-    -- Move persona slots upward to better utilize vertical space
-    slotsFrame.Position = UDim2.fromScale(0.5,0.6)
+    slotsFrame.Position = UDim2.fromScale(0.5,0.5)
     slotsFrame.AnchorPoint = Vector2.new(0.5,0.5)
     slotsFrame.BackgroundTransparency = 1
     slotsFrame.BorderSizePixel = 0


### PR DESCRIPTION
## Summary
- triple dojo logo size to emphasize branding
- drop "Persona Slots" header and shift persona selection up under dojo image

## Testing
- `selene` *(fails: command not found)*
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd236d4d7c833291d9167566e0e650