### PR TITLE
Adjust shop UI and remove ability button

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -162,11 +162,18 @@ root.Parent = ui
 
 BootUI.root = root
 Cosmetics.init(config, root, BootUI)
-local function toggleShop()
+local function toggleShop(defaultTab)
     if not BootUI.shopFrame then
-        BootUI.shopFrame = ShopUI.init(config, shop, BootUI)
+        BootUI.shopFrame = ShopUI.init(config, shop, BootUI, defaultTab)
     else
         BootUI.shopFrame.Visible = not BootUI.shopFrame.Visible
+    end
+    if BootUI.shopFrame and BootUI.shopFrame.Visible and defaultTab then
+        if ShopUI.setTab then
+            ShopUI.setTab(defaultTab)
+        elseif BootUI.shopFrame.SetTab then
+            BootUI.shopFrame:SetTab(defaultTab)
+        end
     end
 end
 BootUI.toggleShop = toggleShop
@@ -185,7 +192,8 @@ end
 BootUI.toggleAbilities = toggleAbilities
 local shopBtn = Instance.new("TextButton")
 shopBtn.Size = UDim2.fromOffset(120,40)
-shopBtn.Position = UDim2.fromOffset(20,20)
+shopBtn.AnchorPoint = Vector2.new(1,1)
+shopBtn.Position = UDim2.new(1,-20,1,-20)
 shopBtn.Text = "Shop"
 shopBtn.Font = Enum.Font.GothamSemibold
 shopBtn.TextScaled = true
@@ -196,22 +204,9 @@ shopBtn.ZIndex = 10
 shopBtn.Parent = root
 shopBtn.Visible = false
 BootUI.shopBtn = shopBtn
-shopBtn.Activated:Connect(toggleShop)
-
-local abilityBtn = Instance.new("TextButton")
-abilityBtn.Size = UDim2.fromOffset(120,40)
-abilityBtn.Position = UDim2.fromOffset(150,20)
-abilityBtn.Text = "Abilities"
-abilityBtn.Font = Enum.Font.GothamSemibold
-abilityBtn.TextScaled = true
-abilityBtn.TextColor3 = Color3.new(1,1,1)
-abilityBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
-abilityBtn.AutoButtonColor = true
-abilityBtn.ZIndex = 10
-abilityBtn.Parent = root
-abilityBtn.Visible = false
-BootUI.abilityBtn = abilityBtn
-abilityBtn.Activated:Connect(toggleAbilities)
+shopBtn.Activated:Connect(function()
+    toggleShop()
+end)
 TeleportClient.init(root)
 
 -- Intro visuals

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -127,7 +127,6 @@ local function showDojoPicker()
     if boot then
         if boot.loadout then boot.loadout.Visible = false end
         if boot.shopBtn then boot.shopBtn.Visible = false end
-        if boot.abilityBtn then boot.abilityBtn.Visible = false end
     end
 end
 
@@ -135,7 +134,6 @@ local function showLoadout(personaType)
     if dojo then dojo.Visible = false end
     if boot then
         if boot.shopBtn then boot.shopBtn.Visible = true end
-        if boot.abilityBtn then boot.abilityBtn.Visible = true end
         if boot.loadout then
             boot.loadout.Visible = true
             if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end


### PR DESCRIPTION
## Summary
- reposition shop button to bottom-right corner
- remove standalone ability button
- allow specifying default tab when toggling shop

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua`
- `luac -p ReplicatedStorage/BootModules/Cosmetics.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bdca9b64f88332a2652f7e85f27b6e