### PR TITLE
Add tabbed shop interface with ability purchases

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -38,7 +38,6 @@ local Cosmetics       = require(ReplicatedStorage.BootModules.Cosmetics)
 local CurrencyService = require(ReplicatedStorage.BootModules.CurrencyService)
 local Shop            = require(ReplicatedStorage.BootModules.Shop)
 local ShopUI          = require(ReplicatedStorage.BootModules.ShopUI)
-local AbilityUI       = require(ReplicatedStorage.BootModules.AbilityUI)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
 
 -- =====================
@@ -180,16 +179,6 @@ BootUI.toggleShop = toggleShop
 if config.showShop then
     toggleShop()
 end
-
-local abilityFrame
-local function toggleAbilities()
-    if not abilityFrame then
-        abilityFrame = AbilityUI.init(config, BootUI)
-    else
-        abilityFrame.Visible = not abilityFrame.Visible
-    end
-end
-BootUI.toggleAbilities = toggleAbilities
 local shopBtn = Instance.new("TextButton")
 shopBtn.Size = UDim2.fromOffset(120,40)
 shopBtn.AnchorPoint = Vector2.new(1,1)


### PR DESCRIPTION
## Summary
- Remove legacy AbilityUI from boot sequence
- Introduce tabbed Shop UI with Elements, Abilities and Weapons categories
- Populate Abilities tab from metadata and route purchases through existing shop logic

## Testing
- `luacheck ReplicatedStorage/BootModules/BootUI.lua ReplicatedStorage/BootModules/ShopUI.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb8f91a48332b78aa1b8c1d6fc73