### PR TITLE
Unlock Atoms realm by default

### DIFF
--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -36,6 +36,7 @@ local DEFAULT_DATA = {
     unlockedRealms = {
         StarterDojo = true,
         SecretVillage = true,
+        Atoms = true,
     },
     inventory = {
         coins = 0,


### PR DESCRIPTION
## Summary
- Ensure players start with Atoms realm unlocked so teleporting between Dojo, Atoms, and Elementara is always possible

## Testing
- `luac -p ServerScriptService/DataSavingScript.lua` *(fails: '=' expected near '+')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd222c1a48332adf459e324d6dde3