### PR TITLE
Fix shop usability and inventory attribute handling

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -169,8 +169,6 @@ local function toggleShop(defaultTab)
     if BootUI.shopFrame and BootUI.shopFrame.Visible and defaultTab then
         if ShopUI.setTab then
             ShopUI.setTab(defaultTab)
-        elseif BootUI.shopFrame.SetTab then
-            BootUI.shopFrame:SetTab(defaultTab)
         end
     end
 end

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -3,6 +3,7 @@ local Cosmetics = {}
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local TweenService = game:GetService("TweenService")
+local HttpService = game:GetService("HttpService")
 
 local rf = ReplicatedStorage:WaitForChild("PersonaServiceRF")
 local player = Players.LocalPlayer
@@ -139,16 +140,22 @@ local function showLoadout(personaType)
             if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
             if boot.populateBackpackUI then
                 local saved = player:GetAttribute("Inventory")
-                if saved then
-                    boot.populateBackpackUI(saved)
+                if typeof(saved) == "string" then
+                    local ok, data = pcall(HttpService.JSONDecode, HttpService, saved)
+                    if ok then
+                        boot.populateBackpackUI(data)
+                    end
                 elseif boot.StarterBackpack then
                     boot.populateBackpackUI(boot.StarterBackpack)
                     local conn
                     conn = player:GetAttributeChangedSignal("Inventory"):Connect(function()
                         local inv = player:GetAttribute("Inventory")
-                        if inv then
-                            boot.populateBackpackUI(inv)
-                            conn:Disconnect()
+                        if typeof(inv) == "string" then
+                            local ok, data = pcall(HttpService.JSONDecode, HttpService, inv)
+                            if ok then
+                                boot.populateBackpackUI(data)
+                                conn:Disconnect()
+                            end
                         end
                     end)
                 end

--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -101,8 +101,22 @@ function ShopUI.init(config, shop, bootUI, defaultTab)
         end
     end
 
-    frame.SetTab = ShopUI.setTab
     ShopUI.setTab(defaultTab or names[1])
+
+    local closeBtn = Instance.new("TextButton")
+    closeBtn.Size = UDim2.fromOffset(24,24)
+    closeBtn.AnchorPoint = Vector2.new(1,0)
+    closeBtn.Position = UDim2.new(1,-4,0,4)
+    closeBtn.Text = "X"
+    closeBtn.Font = Enum.Font.GothamBold
+    closeBtn.TextScaled = true
+    closeBtn.TextColor3 = Color3.new(1,1,1)
+    closeBtn.BackgroundColor3 = Color3.fromRGB(200,60,60)
+    closeBtn.ZIndex = 2
+    closeBtn.Parent = frame
+    closeBtn.Activated:Connect(function()
+        frame.Visible = false
+    end)
 
     return frame
 end

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -1,6 +1,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local MerchBooth = require(ReplicatedStorage:WaitForChild("MerchBooth"))
+local merchModule = ReplicatedStorage:FindFirstChild("MerchBooth")
+if not merchModule then
+    warn("MerchBooth module not found")
+    return
+end
+
+local MerchBooth = require(merchModule)
 
 local items = {
 	125630227934002,  -- MetalMagic

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -9,7 +9,8 @@ local Abilities = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitFo
 local AudioPlayer = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AudioPlayer"))
 local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
 local CombatController = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CombatController"))
-local MerchBooth = require(ReplicatedStorage:WaitForChild("MerchBooth"))
+local merchModule = ReplicatedStorage:FindFirstChild("MerchBooth")
+local MerchBooth = merchModule and require(merchModule)
 local GameSettings = require(ReplicatedStorage:WaitForChild("GameSettings"))
 
 local player = Players.LocalPlayer
@@ -19,11 +20,14 @@ local PlayerGui = player:WaitForChild("PlayerGui")
 CharacterManager.setup(player)
 CombatController.initAnimations()
 
--- Merch Booth setup
-MerchBooth.toggleCatalogButton(true)
-MerchBooth.configure({
-	disableCharacterMovement = true
-})
+if MerchBooth then
+        MerchBooth.toggleCatalogButton(true)
+        MerchBooth.configure({
+                disableCharacterMovement = true
+        })
+else
+        warn("MerchBooth module missing")
+end
 
 --local ts = game:GetService("TweenService")
 --local currentCamera = game.Workspace.CurrentCamera
@@ -59,22 +63,23 @@ player.CharacterAdded:Connect(onCharacterAdded)
 
 -- Merch touch region
 local function setupRegion(region: BasePart)
-	region.Touched:Connect(function(otherPart)
-		local character = Players.LocalPlayer.Character
-		if character and otherPart == character.PrimaryPart then
-			MerchBooth.openMerchBooth()
-		end
-	end)
-	region.TouchEnded:Connect(function(otherPart)
-		local character = Players.LocalPlayer.Character
-		if character and otherPart == character.PrimaryPart then
-			MerchBooth.closeMerchBooth()
-		end
-	end)
+        if not MerchBooth then return end
+        region.Touched:Connect(function(otherPart)
+                local character = Players.LocalPlayer.Character
+                if character and otherPart == character.PrimaryPart then
+                        MerchBooth.openMerchBooth()
+                end
+        end)
+        region.TouchEnded:Connect(function(otherPart)
+                local character = Players.LocalPlayer.Character
+                if character and otherPart == character.PrimaryPart then
+                        MerchBooth.closeMerchBooth()
+                end
+        end)
 end
 
 for _, region in CollectionService:GetTagged("ShopRegion") do
-	setupRegion(region)
+        setupRegion(region)
 end
 CollectionService:GetInstanceAddedSignal("ShopRegion"):Connect(setupRegion)
 


### PR DESCRIPTION
## Summary
- Serialize player inventory to JSON to avoid dictionary attribute errors
- Add a close button to the shop UI and clean up tab handling
- Guard merch booth scripts to prevent infinite yield when module is missing

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bddab20ce08332995eb839df917199