### PR TITLE
Preserve personas and limit slots

### DIFF
--- a/ReplicatedStorage/GameSettings.lua
+++ b/ReplicatedStorage/GameSettings.lua
@@ -21,7 +21,7 @@ GameSettings.startPoints = 0
 GameSettings.startCoins = 100
 
 -- Maximum number of persona slots available to each player
-GameSettings.maxSlots = 9
+GameSettings.maxSlots = 3
 
 GameSettings.pointsName = "Points"
 GameSettings.upgradeName = "Upgrades"

--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -33,11 +33,19 @@ local DEFAULT_DATA = {
         Atom = 0,
     },
     unlockedAbilities = {},
-    -- realms the player has unlocked; defaults to starter areas
+    -- realms the player has unlocked; start with all locked
     unlockedRealms = {
-        StarterDojo = true,
-        SecretVillage = true,
-        Atoms = true,
+        StarterDojo = false,
+        SecretVillage = false,
+        Water = false,
+        Fire = false,
+        Wind = false,
+        Growth = false,
+        Ice = false,
+        Light = false,
+        Metal = false,
+        Strength = false,
+        Atoms = false,
     },
     inventory = {
         coins = 0,


### PR DESCRIPTION
## Summary
- Preserve higher persona slots when clearing lower ones by saving as dictionary and restoring as array
- Hide unused persona slots in BootUI, showing only filled slots plus one extra up to three slots
- Limit persona slots to three and start all realms locked for new personas

## Testing
- ⚠️ `luau -v` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdecead8008332b901fddaa0d75ee8