### PR TITLE
Support singular HumanoidDescription folder name

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -691,7 +691,10 @@ local function buildCharacterPreview(personaType)
     -- get a HumanoidDescription
     local desc
     if personaType == "Ninja" then
+        -- Expected folder "HumanoidDescriptions" contains client-visible HumanoidDescription assets.
+        -- Fall back to singular name if an older structure is present.
         local hdFolder = ReplicatedStorage:FindFirstChild("HumanoidDescriptions")
+            or ReplicatedStorage:FindFirstChild("HumanoidDescription")
         local hd = hdFolder and hdFolder:FindFirstChild("Ninja")
         if hd then desc = hd:Clone() end
     else

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -109,18 +109,21 @@ local function highestUsed()
 end
 
 local function getDescription(personaType)
-	local desc
-	if personaType == "Ninja" then
-		local hdFolder = ReplicatedStorage:FindFirstChild("HumanoidDescriptions")
-		local hd = hdFolder and hdFolder:FindFirstChild("Ninja")
-		if hd then desc = hd:Clone() end
-	else
-		local ok, hd = pcall(function()
-			return Players:GetHumanoidDescriptionFromUserId(player.UserId)
-		end)
-		if ok then desc = hd end
-	end
-	return desc
+       local desc
+       if personaType == "Ninja" then
+               -- Expected folder "HumanoidDescriptions" contains shared HumanoidDescription assets.
+               -- Use singular name as a fallback for legacy content.
+               local hdFolder = ReplicatedStorage:FindFirstChild("HumanoidDescriptions")
+                       or ReplicatedStorage:FindFirstChild("HumanoidDescription")
+               local hd = hdFolder and hdFolder:FindFirstChild("Ninja")
+               if hd then desc = hd:Clone() end
+       else
+               local ok, hd = pcall(function()
+                       return Players:GetHumanoidDescriptionFromUserId(player.UserId)
+               end)
+               if ok then desc = hd end
+       end
+       return desc
 end
 
 local function updateSlots()

--- a/ServerScriptService/PersonaService.server.lua
+++ b/ServerScriptService/PersonaService.server.lua
@@ -46,8 +46,10 @@ local function playerKey(userId) return "u_"..tostring(userId) end
 
 -- Resolve the Ninja HumanoidDescription from either ReplicatedStorage (HD) or ServerStorage (Model)
 local function resolveNinjaHD()
-	-- Preferred: client-visible HumanoidDescription (also used by viewport)
-	local rFolder = ReplicatedStorage:FindFirstChild("HumanoidDescriptions")
+       -- Preferred: client-visible HumanoidDescription folder is "HumanoidDescriptions".
+       -- Some older content used the singular name; fall back for compatibility.
+       local rFolder = ReplicatedStorage:FindFirstChild("HumanoidDescriptions")
+               or ReplicatedStorage:FindFirstChild("HumanoidDescription")
 	local hd = rFolder and rFolder:FindFirstChild("Ninja")
 	if hd and hd:IsA("HumanoidDescription") then return hd end
 


### PR DESCRIPTION
## Summary
- gracefully handle `ReplicatedStorage/HumanoidDescription` as a fallback when `HumanoidDescriptions` is missing
- note expected plural folder name to avoid future confusion

## Testing
- `selene .` *(fails: command not found)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68be639738f88332b673fa7a807ac624