### PR TITLE
feat: extract loading screen into PersonaUI

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -53,11 +53,6 @@ BootUI.shop = shop
 -- =====================
 local CAM_TWEEN_TIME = 1.6
 
-local ASSETS = {
-    Logo     = "rbxassetid://138217463115431",
-    PaperTex = "rbxassetid://131504699316598",
-}
-
 local StarterBackpack = config.starterBackpack or {
     capacity = 20,
     weapons = {},
@@ -196,55 +191,6 @@ end)
 TeleportClient.init(root)
 
 -- Intro visuals
-local paperBG = Instance.new("ImageLabel")
-paperBG.Size = UDim2.fromScale(1,1)
-paperBG.BackgroundTransparency = 1
-paperBG.Image = ASSETS.PaperTex
-paperBG.ScaleType = Enum.ScaleType.Tile
-paperBG.TileSize = UDim2.fromOffset(256,256)
-paperBG.ImageTransparency = 0.12
-paperBG.ImageColor3 = Color3.fromRGB(250,235,220)
-paperBG.ZIndex = 1
-paperBG.Parent = root
-
-local logoImg = Instance.new("ImageLabel")
-logoImg.Size = UDim2.fromScale(0.3,0.3)
-logoImg.Position = UDim2.fromScale(0.5,0.25)
-logoImg.AnchorPoint = Vector2.new(0.5,0.5)
-logoImg.BackgroundTransparency = 1
-logoImg.Image = ASSETS.Logo
-logoImg.ZIndex = 5
-logoImg.Parent = root
-Instance.new("UIAspectRatioConstraint", logoImg).AspectRatio = 1
-
-local sub = Instance.new("TextLabel")
-sub.Size = UDim2.fromScale(0.6,0.05)
-sub.Position = UDim2.fromScale(0.5,0.44)
-sub.AnchorPoint = Vector2.new(0.5,0.5)
-sub.Text = "Loading…"
-sub.Font = Enum.Font.Gotham
-sub.TextScaled = true
-sub.TextColor3 = Color3.fromRGB(230,230,230)
-sub.BackgroundTransparency = 1
-sub.ZIndex = 5
-sub.Parent = root
-
-local barBG = Instance.new("Frame")
-barBG.Size = UDim2.new(0.6,0,0.01,0)
-barBG.Position = UDim2.fromScale(0.2,0.49)
-barBG.BackgroundColor3 = Color3.fromRGB(40,40,42)
-barBG.BorderSizePixel = 0
-barBG.ZIndex = 4
-barBG.Parent = root
-
-local bar = Instance.new("Frame")
-bar.Size = UDim2.new(0,0,0.01,0)
-bar.Position = UDim2.fromScale(0.2,0.49)
-bar.BackgroundColor3 = Color3.fromRGB(255,60,60)
-bar.BorderSizePixel = 0
-bar.ZIndex = 6
-bar.Parent = root
-
 local fade = Instance.new("Frame")
 fade.Size = UDim2.fromScale(1,1)
 fade.BackgroundColor3 = Color3.new(0,0,0)
@@ -873,25 +819,6 @@ wireEmoteButtons()
 cam.CameraType = Enum.CameraType.Scriptable
 holdStartCam(1.0)
 disableUIBlur()
-
-local items = {}
-if ASSETS.Logo ~= "" then table.insert(items, logoImg) end
-if ASSETS.PaperTex ~= "" then table.insert(items, paperBG) end
-pcall(function() ContentProvider:PreloadAsync(items) end)
-
-bar.Size = UDim2.new(0,0,0.01,0)
-TweenService:Create(bar, TweenInfo.new(1.6, Enum.EasingStyle.Quad), {Size = UDim2.new(0.6,0,0.01,0)}):Play()
-wait(1.65)
-
-local t = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
-TweenService:Create(sub, t, {TextTransparency = 1}):Play()
-TweenService:Create(bar,  t, {BackgroundTransparency = 1}):Play()
-TweenService:Create(barBG, t, {BackgroundTransparency = 1}):Play()
-TweenService:Create(logoImg, t, {ImageTransparency = 1}):Play()
-TweenService:Create(paperBG, t, {ImageTransparency = 1}):Play()
-wait(0.28)
-if logoImg then logoImg:Destroy() end
-if paperBG then paperBG:Destroy() end
 
 Cosmetics.showDojoPicker()
 -- We do NOT tween to end here anymore; only after "Use".

--- a/ReplicatedStorage/BootModules/PersonaUI.lua
+++ b/ReplicatedStorage/BootModules/PersonaUI.lua
@@ -1,0 +1,101 @@
+local PersonaUI = {}
+
+function PersonaUI.start(config)
+    config = config or {}
+
+    local Players = game:GetService("Players")
+    local TweenService = game:GetService("TweenService")
+    local ContentProvider = game:GetService("ContentProvider")
+
+    local player = Players.LocalPlayer
+
+    local ASSETS = {
+        Logo     = "rbxassetid://138217463115431",
+        PaperTex = "rbxassetid://131504699316598",
+    }
+
+    local gui = Instance.new("ScreenGui")
+    gui.ResetOnSpawn   = false
+    gui.Name           = "IntroGui"
+    gui.IgnoreGuiInset = true
+    gui.DisplayOrder   = 100
+    gui.Parent         = player:WaitForChild("PlayerGui")
+
+    local root = Instance.new("Frame")
+    root.Size = UDim2.fromScale(1,1)
+    root.BackgroundTransparency = 1
+    root.Parent = gui
+
+    local paperBG = Instance.new("ImageLabel")
+    paperBG.Size = UDim2.fromScale(1,1)
+    paperBG.BackgroundTransparency = 1
+    paperBG.Image = ASSETS.PaperTex
+    paperBG.ScaleType = Enum.ScaleType.Tile
+    paperBG.TileSize = UDim2.fromOffset(256,256)
+    paperBG.ImageTransparency = 0.12
+    paperBG.ImageColor3 = Color3.fromRGB(250,235,220)
+    paperBG.ZIndex = 1
+    paperBG.Parent = root
+
+    local logoImg = Instance.new("ImageLabel")
+    logoImg.Size = UDim2.fromScale(0.3,0.3)
+    logoImg.Position = UDim2.fromScale(0.5,0.25)
+    logoImg.AnchorPoint = Vector2.new(0.5,0.5)
+    logoImg.BackgroundTransparency = 1
+    logoImg.Image = ASSETS.Logo
+    logoImg.ZIndex = 5
+    logoImg.Parent = root
+    Instance.new("UIAspectRatioConstraint", logoImg).AspectRatio = 1
+
+    local sub = Instance.new("TextLabel")
+    sub.Size = UDim2.fromScale(0.6,0.05)
+    sub.Position = UDim2.fromScale(0.5,0.44)
+    sub.AnchorPoint = Vector2.new(0.5,0.5)
+    sub.Text = "Loading…"
+    sub.Font = Enum.Font.Gotham
+    sub.TextScaled = true
+    sub.TextColor3 = Color3.fromRGB(230,230,230)
+    sub.BackgroundTransparency = 1
+    sub.ZIndex = 5
+    sub.Parent = root
+
+    local barBG = Instance.new("Frame")
+    barBG.Size = UDim2.new(0.6,0,0.01,0)
+    barBG.Position = UDim2.fromScale(0.2,0.49)
+    barBG.BackgroundColor3 = Color3.fromRGB(40,40,42)
+    barBG.BorderSizePixel = 0
+    barBG.ZIndex = 4
+    barBG.Parent = root
+
+    local bar = Instance.new("Frame")
+    bar.Size = UDim2.new(0,0,0.01,0)
+    bar.Position = UDim2.fromScale(0.2,0.49)
+    bar.BackgroundColor3 = Color3.fromRGB(255,60,60)
+    bar.BorderSizePixel = 0
+    bar.ZIndex = 6
+    bar.Parent = root
+
+    local items = {}
+    if ASSETS.Logo ~= "" then table.insert(items, logoImg) end
+    if ASSETS.PaperTex ~= "" then table.insert(items, paperBG) end
+    pcall(function()
+        ContentProvider:PreloadAsync(items)
+    end)
+
+    bar.Size = UDim2.new(0,0,0.01,0)
+    TweenService:Create(bar, TweenInfo.new(1.6, Enum.EasingStyle.Quad), {Size = UDim2.new(0.6,0,0.01,0)}):Play()
+    wait(1.65)
+
+    local t = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+    TweenService:Create(sub, t, {TextTransparency = 1}):Play()
+    TweenService:Create(bar,  t, {BackgroundTransparency = 1}):Play()
+    TweenService:Create(barBG, t, {BackgroundTransparency = 1}):Play()
+    TweenService:Create(logoImg, t, {ImageTransparency = 1}):Play()
+    TweenService:Create(paperBG, t, {ImageTransparency = 1}):Play()
+    wait(0.28)
+
+    gui:Destroy()
+end
+
+return PersonaUI
+

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -2,5 +2,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local BootModules = ReplicatedStorage:WaitForChild("BootModules")
 
+local PersonaUI = require(BootModules:WaitForChild("PersonaUI"))
+PersonaUI.start()
+
 local BootUI = require(BootModules:WaitForChild("BootUI"))
 BootUI.start()


### PR DESCRIPTION
## Summary
- add PersonaUI module to handle initial loading screen
- simplify BootUI by removing loading screen creation
- start PersonaUI before BootUI in boot client script

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua`
- `luac -p ReplicatedStorage/BootModules/PersonaUI.lua`
- `luac -p StarterPlayer/StarterPlayerScripts/Boot.client.lua`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5aeff63483329e1b87bb3fbcddae