### PR TITLE
Split Dojo UI into quest and backpack panels

### DIFF
--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -9,7 +9,9 @@ local ContentProvider = game:GetService("ContentProvider")
 local rf = ReplicatedStorage:WaitForChild("PersonaServiceRF")
 local player = Players.LocalPlayer
 
-local dojo
+local dojoFrame
+local dojoQuestPanel
+local dojoBackpackPanel
 local slotButtons = {}
 local boot
 local rootUI
@@ -206,19 +208,15 @@ refreshSlots = function()
 end
 
 local function showDojoPicker()
-	if dojo then dojo.Visible = true end
-	if boot then
-		if boot.loadout then boot.loadout.Visible = false end
-		if boot.shopBtn then boot.shopBtn.Visible = false end
-	end
+        if dojoQuestPanel then dojoQuestPanel.Visible = true end
 end
 
 local function showLoadout(personaType)
-	if dojo then dojo.Visible = false end
-	if boot then
-		if boot.shopBtn then boot.shopBtn.Visible = true end
-		if boot.loadout then
-			boot.loadout.Visible = true
+        if dojoQuestPanel then dojoQuestPanel.Visible = false end
+        if boot then
+                if boot.shopBtn then boot.shopBtn.Visible = true end
+                if boot.loadout then
+                        boot.loadout.Visible = true
 			if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
 			if boot.populateBackpackUI then
 				local saved = player:GetAttribute("Inventory")
@@ -287,44 +285,67 @@ function Cosmetics.init(config, root, bootUI)
 	end
 	player:GetAttributeChangedSignal("Level"):Connect(updateLevelLabels)
 
-	dojo = Instance.new("Frame")
-	dojo.Size = UDim2.fromScale(1,1)
-	dojo.BackgroundTransparency = 1
-	dojo.Visible = false
-	dojo.ZIndex = 10
-	dojo.Parent = root
+        dojoFrame = Instance.new("Frame")
+        dojoFrame.Size = UDim2.fromScale(1,1)
+        dojoFrame.BackgroundTransparency = 1
+        dojoFrame.ZIndex = 10
+        dojoFrame.Parent = root
 
-	local dojoTitle = Instance.new("ImageLabel")
-	dojoTitle.Size = UDim2.fromScale(0.7,0.24)
-	dojoTitle.Position = UDim2.fromScale(0.5,0.1)
-	dojoTitle.AnchorPoint = Vector2.new(0.5,0.5)
-	-- Use BootUI logo where starter dojo image was
-	dojoTitle.Image = "rbxassetid://138217463115431"
-	dojoTitle.BackgroundTransparency = 1
-	dojoTitle.ScaleType = Enum.ScaleType.Fit
-	dojoTitle.ZIndex = 11
-	dojoTitle.Parent = dojo
+        dojoQuestPanel = Instance.new("Frame")
+        dojoQuestPanel.Name = "DojoQuestPanel"
+        dojoQuestPanel.Size = UDim2.new(0.5,0,1,0)
+        dojoQuestPanel.BackgroundTransparency = 1
+        dojoQuestPanel.Visible = false
+        dojoQuestPanel.Parent = dojoFrame
 
-	local picker = Instance.new("Frame")
-	picker.Size = UDim2.fromScale(0.8,0.7)
-	picker.Position = UDim2.fromScale(0.5,0.55)
-	picker.AnchorPoint = Vector2.new(0.5,0.5)
-	picker.BackgroundColor3 = Color3.fromRGB(24,26,28)
-	picker.BackgroundTransparency = 0.6
-	picker.BorderSizePixel = 0
-	picker.ZIndex = 11
-	picker.Parent = dojo
+        dojoBackpackPanel = Instance.new("Frame")
+        dojoBackpackPanel.Name = "DojoBackpackPanel"
+        dojoBackpackPanel.Size = UDim2.new(0.5,0,1,0)
+        dojoBackpackPanel.Position = UDim2.fromScale(0.5,0)
+        dojoBackpackPanel.BackgroundTransparency = 1
+        dojoBackpackPanel.Parent = dojoFrame
 
-	-- Display starter dojo image at the bottom of the picker
-	local starterDojoImg = Instance.new("ImageLabel")
-	starterDojoImg.Size = UDim2.fromScale(0.7,0.08)
-	starterDojoImg.Position = UDim2.fromScale(0.5,0.92)
-	starterDojoImg.AnchorPoint = Vector2.new(0.5,1)
-	starterDojoImg.Image = "rbxassetid://137361385013636"
-	starterDojoImg.BackgroundTransparency = 1
-	starterDojoImg.ScaleType = Enum.ScaleType.Fit
-	starterDojoImg.ZIndex = 12
-	starterDojoImg.Parent = picker
+        if boot then
+                boot.DojoBackpackPanel = dojoBackpackPanel
+                task.spawn(function()
+                        while not boot.loadout do task.wait() end
+                        boot.loadout.Parent = dojoBackpackPanel
+                        boot.loadout.Size = UDim2.fromScale(1,1)
+                        boot.loadout.Position = UDim2.new(0,0,0,0)
+                end)
+        end
+
+        local dojoTitle = Instance.new("ImageLabel")
+        dojoTitle.Size = UDim2.fromScale(0.7,0.24)
+        dojoTitle.Position = UDim2.fromScale(0.5,0.1)
+        dojoTitle.AnchorPoint = Vector2.new(0.5,0.5)
+        -- Use BootUI logo where starter dojo image was
+        dojoTitle.Image = "rbxassetid://138217463115431"
+        dojoTitle.BackgroundTransparency = 1
+        dojoTitle.ScaleType = Enum.ScaleType.Fit
+        dojoTitle.ZIndex = 11
+        dojoTitle.Parent = dojoQuestPanel
+
+        local picker = Instance.new("Frame")
+        picker.Size = UDim2.fromScale(0.8,0.7)
+        picker.Position = UDim2.fromScale(0.5,0.55)
+        picker.AnchorPoint = Vector2.new(0.5,0.5)
+        picker.BackgroundColor3 = Color3.fromRGB(24,26,28)
+        picker.BackgroundTransparency = 0.6
+        picker.BorderSizePixel = 0
+        picker.ZIndex = 11
+        picker.Parent = dojoQuestPanel
+
+        -- Display starter dojo image at the bottom of the picker
+        local starterDojoImg = Instance.new("ImageLabel")
+        starterDojoImg.Size = UDim2.fromScale(0.7,0.08)
+        starterDojoImg.Position = UDim2.fromScale(0.5,0.92)
+        starterDojoImg.AnchorPoint = Vector2.new(0.5,1)
+        starterDojoImg.Image = "rbxassetid://137361385013636"
+        starterDojoImg.BackgroundTransparency = 1
+        starterDojoImg.ScaleType = Enum.ScaleType.Fit
+        starterDojoImg.ZIndex = 12
+        starterDojoImg.Parent = picker
 
 	local function makeButton(text, y)
 		local b = Instance.new("TextButton")


### PR DESCRIPTION
## Summary
- Split Dojo interface into left `DojoQuestPanel` and right `DojoBackpackPanel`
- Updated `showDojoPicker` to only toggle quest panel visibility
- Reparent loadout UI into the new backpack panel

## Testing
- `luau -p ReplicatedStorage/BootModules/Cosmetics.lua` *(fails: command not found)*
- `lua -p ReplicatedStorage/BootModules/Cosmetics.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5ccfba048332831fc09b0800b892