### PR TITLE
Split Dojo UI into quest and backpack panels

### DIFF
--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -9,7 +9,9 @@ local ContentProvider = game:GetService("ContentProvider")
 local rf = ReplicatedStorage:WaitForChild("PersonaServiceRF")
 local player = Players.LocalPlayer
 
-local dojo
+local dojoFrame
+local dojoQuestPanel
+local dojoBackpackPanel
 local slotButtons = {}
 local boot
 local rootUI
@@ -206,44 +208,60 @@ refreshSlots = function()
 end
 
 local function showDojoPicker()
-	if dojo then dojo.Visible = true end
-	if boot then
-		if boot.loadout then boot.loadout.Visible = false end
-		if boot.shopBtn then boot.shopBtn.Visible = false end
-	end
+        if dojoFrame then dojoFrame.Visible = true end
+        if dojoQuestPanel then dojoQuestPanel.Visible = true end
+        if boot then
+                if boot.loadout then
+                        boot.loadout.Parent = dojoBackpackPanel
+                        boot.loadout.Size = UDim2.fromScale(1,1)
+                        boot.loadout.Position = UDim2.new(0,0,0,0)
+                        boot.loadout.Visible = true
+                end
+                if boot.shopBtn then
+                        boot.shopBtn.Parent = dojoBackpackPanel
+                        boot.shopBtn.Visible = true
+                end
+        end
 end
 
 local function showLoadout(personaType)
-	if dojo then dojo.Visible = false end
-	if boot then
-		if boot.shopBtn then boot.shopBtn.Visible = true end
-		if boot.loadout then
-			boot.loadout.Visible = true
-			if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
-			if boot.populateBackpackUI then
-				local saved = player:GetAttribute("Inventory")
-				if typeof(saved) == "string" then
-					local ok, data = pcall(HttpService.JSONDecode, HttpService, saved)
-					if ok then
-						boot.populateBackpackUI(data)
-					end
-				elseif boot.StarterBackpack then
-					boot.populateBackpackUI(boot.StarterBackpack)
-					local conn
-					conn = player:GetAttributeChangedSignal("Inventory"):Connect(function()
-						local inv = player:GetAttribute("Inventory")
-						if typeof(inv) == "string" then
-							local ok, data = pcall(HttpService.JSONDecode, HttpService, inv)
-							if ok then
-								boot.populateBackpackUI(data)
-								conn:Disconnect()
-							end
-						end
-					end)
-				end
-			end
-		end
-	end
+        if dojoQuestPanel then dojoQuestPanel.Visible = false end
+        if dojoFrame then dojoFrame.Visible = false end
+        if boot then
+                if boot.shopBtn then
+                        boot.shopBtn.Parent = rootUI
+                        boot.shopBtn.Visible = true
+                end
+                if boot.loadout then
+                        boot.loadout.Parent = rootUI
+                        boot.loadout.Size = UDim2.fromScale(1,1)
+                        boot.loadout.Position = UDim2.new(0,0,0,0)
+                        boot.loadout.Visible = true
+                        if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
+                        if boot.populateBackpackUI then
+                                local saved = player:GetAttribute("Inventory")
+                                if typeof(saved) == "string" then
+                                        local ok, data = pcall(HttpService.JSONDecode, HttpService, saved)
+                                        if ok then
+                                                boot.populateBackpackUI(data)
+                                        end
+                                elseif boot.StarterBackpack then
+                                        boot.populateBackpackUI(boot.StarterBackpack)
+                                        local conn
+                                        conn = player:GetAttributeChangedSignal("Inventory"):Connect(function()
+                                                local inv = player:GetAttribute("Inventory")
+                                                if typeof(inv) == "string" then
+                                                        local ok, data = pcall(HttpService.JSONDecode, HttpService, inv)
+                                                        if ok then
+                                                                boot.populateBackpackUI(data)
+                                                                conn:Disconnect()
+                                                        end
+                                                end
+                                        end)
+                                end
+                        end
+                end
+        end
 end
 
 function Cosmetics.getSelectedPersona()
@@ -287,44 +305,62 @@ function Cosmetics.init(config, root, bootUI)
 	end
 	player:GetAttributeChangedSignal("Level"):Connect(updateLevelLabels)
 
-	dojo = Instance.new("Frame")
-	dojo.Size = UDim2.fromScale(1,1)
-	dojo.BackgroundTransparency = 1
-	dojo.Visible = false
-	dojo.ZIndex = 10
-	dojo.Parent = root
+        dojoFrame = Instance.new("Frame")
+        dojoFrame.Size = UDim2.fromScale(1,1)
+        dojoFrame.BackgroundTransparency = 1
+        dojoFrame.Visible = false
+        dojoFrame.ZIndex = 10
+        dojoFrame.Parent = root
 
-	local dojoTitle = Instance.new("ImageLabel")
-	dojoTitle.Size = UDim2.fromScale(0.7,0.24)
-	dojoTitle.Position = UDim2.fromScale(0.5,0.1)
-	dojoTitle.AnchorPoint = Vector2.new(0.5,0.5)
-	-- Use BootUI logo where starter dojo image was
-	dojoTitle.Image = "rbxassetid://138217463115431"
-	dojoTitle.BackgroundTransparency = 1
-	dojoTitle.ScaleType = Enum.ScaleType.Fit
-	dojoTitle.ZIndex = 11
-	dojoTitle.Parent = dojo
+        dojoQuestPanel = Instance.new("Frame")
+        dojoQuestPanel.Name = "DojoQuestPanel"
+        dojoQuestPanel.Size = UDim2.new(0.5,0,1,0)
+        dojoQuestPanel.BackgroundTransparency = 1
+        dojoQuestPanel.Visible = false
+        dojoQuestPanel.Parent = dojoFrame
 
-	local picker = Instance.new("Frame")
-	picker.Size = UDim2.fromScale(0.8,0.7)
-	picker.Position = UDim2.fromScale(0.5,0.55)
-	picker.AnchorPoint = Vector2.new(0.5,0.5)
-	picker.BackgroundColor3 = Color3.fromRGB(24,26,28)
-	picker.BackgroundTransparency = 0.6
-	picker.BorderSizePixel = 0
-	picker.ZIndex = 11
-	picker.Parent = dojo
+        dojoBackpackPanel = Instance.new("Frame")
+        dojoBackpackPanel.Name = "DojoBackpackPanel"
+        dojoBackpackPanel.Size = UDim2.new(0.5,0,1,0)
+        dojoBackpackPanel.Position = UDim2.fromScale(0.5,0)
+        dojoBackpackPanel.BackgroundTransparency = 1
+        dojoBackpackPanel.Parent = dojoFrame
 
-	-- Display starter dojo image at the bottom of the picker
-	local starterDojoImg = Instance.new("ImageLabel")
-	starterDojoImg.Size = UDim2.fromScale(0.7,0.08)
-	starterDojoImg.Position = UDim2.fromScale(0.5,0.92)
-	starterDojoImg.AnchorPoint = Vector2.new(0.5,1)
-	starterDojoImg.Image = "rbxassetid://137361385013636"
-	starterDojoImg.BackgroundTransparency = 1
-	starterDojoImg.ScaleType = Enum.ScaleType.Fit
-	starterDojoImg.ZIndex = 12
-	starterDojoImg.Parent = picker
+        if boot then
+                boot.DojoBackpackPanel = dojoBackpackPanel
+        end
+
+        local dojoTitle = Instance.new("ImageLabel")
+        dojoTitle.Size = UDim2.fromScale(0.7,0.24)
+        dojoTitle.Position = UDim2.fromScale(0.5,0.1)
+        dojoTitle.AnchorPoint = Vector2.new(0.5,0.5)
+        -- Use BootUI logo where starter dojo image was
+        dojoTitle.Image = "rbxassetid://138217463115431"
+        dojoTitle.BackgroundTransparency = 1
+        dojoTitle.ScaleType = Enum.ScaleType.Fit
+        dojoTitle.ZIndex = 11
+        dojoTitle.Parent = dojoQuestPanel
+
+        local picker = Instance.new("Frame")
+        picker.Size = UDim2.fromScale(0.8,0.7)
+        picker.Position = UDim2.fromScale(0.5,0.55)
+        picker.AnchorPoint = Vector2.new(0.5,0.5)
+        picker.BackgroundColor3 = Color3.fromRGB(24,26,28)
+        picker.BackgroundTransparency = 0.6
+        picker.BorderSizePixel = 0
+        picker.ZIndex = 11
+        picker.Parent = dojoQuestPanel
+
+        -- Display starter dojo image at the bottom of the picker
+        local starterDojoImg = Instance.new("ImageLabel")
+        starterDojoImg.Size = UDim2.fromScale(0.7,0.08)
+        starterDojoImg.Position = UDim2.fromScale(0.5,0.92)
+        starterDojoImg.AnchorPoint = Vector2.new(0.5,1)
+        starterDojoImg.Image = "rbxassetid://137361385013636"
+        starterDojoImg.BackgroundTransparency = 1
+        starterDojoImg.ScaleType = Enum.ScaleType.Fit
+        starterDojoImg.ZIndex = 12
+        starterDojoImg.Parent = picker
 
 	local function makeButton(text, y)
 		local b = Instance.new("TextButton")


### PR DESCRIPTION
## Summary
- Split Dojo UI so loadout and shop button move into a backpack panel when the quest panel is shown
- Hide Dojo frame and restore loadout to full screen when leaving the quest panel
- Initialize Dojo frame hidden without reparenting loadout

## Testing
- `luau -p ReplicatedStorage/BootModules/Cosmetics.lua` *(fails: command not found)*
- `lua -p ReplicatedStorage/BootModules/Cosmetics.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5ccfba048332831fc09b0800b892