### PR TITLE
Add Dojo-specific loading animation and bootstrap integration

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -43,6 +43,7 @@ local CurrencyService = require(ReplicatedStorage.BootModules.CurrencyService)
 local Shop            = require(ReplicatedStorage.BootModules.Shop)
 local ShopUI          = require(ReplicatedStorage.BootModules.ShopUI)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
+local DojoClient      = require(ReplicatedStorage.BootModules.DojoClient)
 
 function BootUI.start(config)
     config = config or {}
@@ -789,6 +790,7 @@ end)
 
 btnEnterRealm.MouseButton1Click:Connect(function()
     if not selectedRealm then return end
+    DojoClient.hide()
     if selectedRealm == "StarterDojo" then
         TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
         task.wait(0.28)

--- a/ReplicatedStorage/BootModules/DojoClient.lua
+++ b/ReplicatedStorage/BootModules/DojoClient.lua
@@ -1,0 +1,47 @@
+local DojoClient = {}
+
+local Players = game:GetService("Players")
+local TweenService = game:GetService("TweenService")
+
+local player = Players.LocalPlayer
+local gui
+
+function DojoClient.start()
+    if gui then return end
+    gui = Instance.new("ScreenGui")
+    gui.Name = "DojoLoadingGui"
+    gui.IgnoreGuiInset = true
+    gui.ResetOnSpawn = false
+    gui.DisplayOrder = 200
+    gui.Parent = player:WaitForChild("PlayerGui")
+
+    local root = Instance.new("Frame")
+    root.Size = UDim2.fromScale(1,1)
+    root.BackgroundColor3 = Color3.fromRGB(0,0,0)
+    root.BackgroundTransparency = 0.2
+    root.Parent = gui
+
+    local label = Instance.new("TextLabel")
+    label.Text = "Entering Dojo..."
+    label.Font = Enum.Font.GothamBold
+    label.TextScaled = true
+    label.TextColor3 = Color3.new(1,1,1)
+    label.Size = UDim2.fromScale(0.6,0.1)
+    label.AnchorPoint = Vector2.new(0.5,0.5)
+    label.Position = UDim2.fromScale(0.5,0.5)
+    label.BackgroundTransparency = 1
+    label.Parent = root
+
+    local tween = TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, -1, true)
+    TweenService:Create(label, tween, {TextTransparency = 0.4}):Play()
+end
+
+function DojoClient.hide()
+    if gui then
+        gui:Destroy()
+        gui = nil
+    end
+end
+
+return DojoClient
+

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -5,6 +5,9 @@ local BootModules = ReplicatedStorage:WaitForChild("BootModules")
 local PersonaUI = require(BootModules:WaitForChild("PersonaUI"))
 PersonaUI.start()
 
+local DojoClient = require(BootModules:WaitForChild("DojoClient"))
+DojoClient.start()
+
 local BootUI = require(BootModules:WaitForChild("BootUI"))
 local config = BootUI.fetchData()
 BootUI.start(config)


### PR DESCRIPTION
## Summary
- Add DojoClient module to show dojo loading animation
- Run DojoClient before BootUI and hide animation after persona selection

## Testing
- `npm test` *(fails: Could not read package.json)*
- `luau --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12140d6d483329eceada88233784b