### PR TITLE
feat: track per-slot inventory and realms

### DIFF
--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -21,6 +21,28 @@ local chosenSlot
 
 local levelValue
 
+local function applyPersonaData(p)
+        if not p then return end
+        if p.inventory then
+                player:SetAttribute("Inventory", HttpService:JSONEncode(p.inventory))
+        end
+        local realms = p.unlockedRealms or p.realms
+        if realms then
+                local folder = player:FindFirstChild("Realms")
+                if folder then
+                        for name, value in pairs(realms) do
+                                local flag = folder:FindFirstChild(name)
+                                if not flag then
+                                        flag = Instance.new("BoolValue")
+                                        flag.Name = name
+                                        flag.Parent = folder
+                                end
+                                flag.Value = value and true or false
+                        end
+                end
+        end
+end
+
 local function getLevel()
 	if levelValue and levelValue.Value then
 		return levelValue.Value
@@ -661,15 +683,16 @@ function Cosmetics.init(config, root, bootUI)
 
 	for i,entry in pairs(slotButtons) do
 		local index = i
-		entry.useBtn.MouseButton1Click:Connect(function()
-			local result = rf:InvokeServer("use", {slot = index})
-			if not (result and result.ok) then warn("Use slot failed:", result and result.err) return end
-			chosenSlot = index
-			currentChoiceType = result.persona and result.persona.type or currentChoiceType
-			if boot and boot.tweenToEnd then boot.tweenToEnd() end
-			showLoadout(result.persona and result.persona.type or currentChoiceType)
-		end)
-		entry.robloxBtn.MouseButton1Click:Connect(function()
+               entry.useBtn.MouseButton1Click:Connect(function()
+                        local result = rf:InvokeServer("use", {slot = index})
+                        if not (result and result.ok) then warn("Use slot failed:", result and result.err) return end
+                        chosenSlot = index
+                        currentChoiceType = result.persona and result.persona.type or currentChoiceType
+                        applyPersonaData(result.persona)
+                        if boot and boot.tweenToEnd then boot.tweenToEnd() end
+                        showLoadout(result.persona and result.persona.type or currentChoiceType)
+                end)
+               entry.robloxBtn.MouseButton1Click:Connect(function()
                         local res = rf:InvokeServer("save", {slot = index, type = "Roblox"})
                         if res and res.ok then
                                 refreshSlots(res)
@@ -677,6 +700,7 @@ function Cosmetics.init(config, root, bootUI)
                                 if useRes and useRes.ok then
                                         chosenSlot = index
                                         currentChoiceType = "Roblox"
+                                        applyPersonaData(useRes.persona)
                                         if boot and boot.tweenToEnd then boot.tweenToEnd() end
                                         showLoadout("Roblox")
                                 else
@@ -685,8 +709,8 @@ function Cosmetics.init(config, root, bootUI)
                         else
                                 warn("Save failed:", res and res.err)
                         end
-		end)
-		entry.starterBtn.MouseButton1Click:Connect(function()
+                end)
+               entry.starterBtn.MouseButton1Click:Connect(function()
                         local res = rf:InvokeServer("save", {slot = index, type = "Ninja"})
                         if res and res.ok then
                                 refreshSlots(res)
@@ -694,6 +718,7 @@ function Cosmetics.init(config, root, bootUI)
                                 if useRes and useRes.ok then
                                         chosenSlot = index
                                         currentChoiceType = "Ninja"
+                                        applyPersonaData(useRes.persona)
                                         if boot and boot.tweenToEnd then boot.tweenToEnd() end
                                         showLoadout("Ninja")
                                 else
@@ -702,7 +727,7 @@ function Cosmetics.init(config, root, bootUI)
                         else
                                 warn("Save failed:", res and res.err)
                         end
-		end)
+                end)
 	end
 end
 

--- a/ServerScriptService/PersonaService.server.lua
+++ b/ServerScriptService/PersonaService.server.lua
@@ -136,25 +136,34 @@ rf.OnServerInvoke = function(player, action, data)
         if action == "get" then
                 return { slots = personas, slotCount = MAX_SLOTS }
 
-	elseif action == "save" then
-		local s = data and tonumber(data.slot)
-		local t = data and tostring(data.type or "")
-		local n = data and tostring(data.name or "")
-                if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
-		if t ~= "Roblox" and t ~= "Ninja" then return {ok=false, err="bad type"} end
+       elseif action == "save" then
+               local s = data and tonumber(data.slot)
+               local t = data and tostring(data.type or "")
+               local n = data and tostring(data.name or "")
+               if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
+               if t ~= "Roblox" and t ~= "Ninja" then return {ok=false, err="bad type"} end
 
-                personas[s] = { type = t, name = (#n > 0 and n) or (t == "Ninja" and "Starter Ninja" or "My Avatar") }
-                persist()
-                return {ok=true, slots = personas}
+               personas[s] = personas[s] or {inventory = {}, unlockedRealms = {}}
+               personas[s].type = t
+               personas[s].name = (#n > 0 and n) or (t == "Ninja" and "Starter Ninja" or "My Avatar")
+               if data.inventory then personas[s].inventory = data.inventory end
+               if data.unlockedRealms or data.realms then
+                       personas[s].unlockedRealms = data.unlockedRealms or data.realms
+               end
+               persist()
+               return {ok=true, slots = personas}
 
-        elseif action == "use" then
-                local s = data and tonumber(data.slot)
-                if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
-                local p = personas[s]
-                if not p then return {ok=false, err="empty slot"} end
+       elseif action == "use" then
+               local s = data and tonumber(data.slot)
+               if not (s and s >= 1 and s <= MAX_SLOTS) then return {ok=false, err="bad slot"} end
+               local p = personas[s]
+               if not p then return {ok=false, err="empty slot"} end
 
-                player:SetAttribute("PersonaType", p.type)
-                return {ok=true, persona=p}
+               player:SetAttribute("PersonaType", p.type)
+               player:SetAttribute("PersonaSlot", s)
+               p.inventory = p.inventory or {}
+               p.unlockedRealms = p.unlockedRealms or {}
+               return {ok=true, persona=p}
 
         elseif action == "clear" then
                 local s = data and tonumber(data.slot)


### PR DESCRIPTION
## Summary
- keep inventory and realm data per persona slot
- load slot data on selection and update player attributes
- persist per-slot inventory and realm info when saving

## Testing
- `selene --version` *(fails: command not found)*
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1269b75fc8332a865f99f05592ab5