### PR TITLE
Show realm name on dojo loading screen

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -791,7 +791,7 @@ end)
 btnEnterRealm.MouseButton1Click:Connect(function()
     if not selectedRealm then return end
     local realmName = selectedRealm
-    DojoClient.start(realmName)
+    DojoClient.start(realmDisplayLookup[realmName])
     if realmName == "StarterDojo" then
         TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
         task.wait(0.28)

--- a/ReplicatedStorage/BootModules/DojoClient.lua
+++ b/ReplicatedStorage/BootModules/DojoClient.lua
@@ -4,36 +4,38 @@ local Players = game:GetService("Players")
 local TweenService = game:GetService("TweenService")
 
 local player = Players.LocalPlayer
-local gui
+local gui, label
 
-function DojoClient.start()
-    if gui then return end
-    gui = Instance.new("ScreenGui")
-    gui.Name = "DojoLoadingGui"
-    gui.IgnoreGuiInset = true
-    gui.ResetOnSpawn = false
-    gui.DisplayOrder = 200
-    gui.Parent = player:WaitForChild("PlayerGui")
+function DojoClient.start(realmName)
+    if not gui then
+        gui = Instance.new("ScreenGui")
+        gui.Name = "DojoLoadingGui"
+        gui.IgnoreGuiInset = true
+        gui.ResetOnSpawn = false
+        gui.DisplayOrder = 200
+        gui.Parent = player:WaitForChild("PlayerGui")
 
-    local root = Instance.new("Frame")
-    root.Size = UDim2.fromScale(1,1)
-    root.BackgroundColor3 = Color3.fromRGB(0,0,0)
-    root.BackgroundTransparency = 0.2
-    root.Parent = gui
+        local root = Instance.new("Frame")
+        root.Size = UDim2.fromScale(1,1)
+        root.BackgroundColor3 = Color3.fromRGB(0,0,0)
+        root.BackgroundTransparency = 0.2
+        root.Parent = gui
 
-    local label = Instance.new("TextLabel")
-    label.Text = "Entering Dojo..."
-    label.Font = Enum.Font.GothamBold
-    label.TextScaled = true
-    label.TextColor3 = Color3.new(1,1,1)
-    label.Size = UDim2.fromScale(0.6,0.1)
-    label.AnchorPoint = Vector2.new(0.5,0.5)
-    label.Position = UDim2.fromScale(0.5,0.5)
-    label.BackgroundTransparency = 1
-    label.Parent = root
+        label = Instance.new("TextLabel")
+        label.Font = Enum.Font.GothamBold
+        label.TextScaled = true
+        label.TextColor3 = Color3.new(1,1,1)
+        label.Size = UDim2.fromScale(0.6,0.1)
+        label.AnchorPoint = Vector2.new(0.5,0.5)
+        label.Position = UDim2.fromScale(0.5,0.5)
+        label.BackgroundTransparency = 1
+        label.Parent = root
 
-    local tween = TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, -1, true)
-    TweenService:Create(label, tween, {TextTransparency = 0.4}):Play()
+        local tween = TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, -1, true)
+        TweenService:Create(label, tween, {TextTransparency = 0.4}):Play()
+    end
+
+    label.Text = "Entering " .. (realmName or "Dojo") .. "..."
 end
 
 function DojoClient.hide()


### PR DESCRIPTION
## Summary
- Pass selected realm's display name to dojo loading overlay
- Make DojoClient accept realm name and update text dynamically

## Testing
- `luacheck ReplicatedStorage/BootModules/DojoClient.lua ReplicatedStorage/BootModules/BootUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_68c1125c33f08332ae0cd67b6649f1d8