### PR TITLE
Use realm names in Dojo loading screen

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -791,7 +791,8 @@ end)
 btnEnterRealm.MouseButton1Click:Connect(function()
     if not selectedRealm then return end
     local realmName = selectedRealm
-    DojoClient.start(realmName)
+    local displayName = realmDisplayLookup[selectedRealm]
+    DojoClient.start(displayName)
     if realmName == "StarterDojo" then
         TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
         task.wait(0.28)

--- a/ReplicatedStorage/BootModules/DojoClient.lua
+++ b/ReplicatedStorage/BootModules/DojoClient.lua
@@ -5,9 +5,14 @@ local TweenService = game:GetService("TweenService")
 
 local player = Players.LocalPlayer
 local gui
+local label
 
-function DojoClient.start()
-    if gui then return end
+function DojoClient.start(realmName)
+    local text = "Entering " .. (realmName or "Dojo") .. "..."
+    if gui then
+        if label then label.Text = text end
+        return
+    end
     gui = Instance.new("ScreenGui")
     gui.Name = "DojoLoadingGui"
     gui.IgnoreGuiInset = true
@@ -21,8 +26,8 @@ function DojoClient.start()
     root.BackgroundTransparency = 0.2
     root.Parent = gui
 
-    local label = Instance.new("TextLabel")
-    label.Text = "Entering Dojo..."
+    label = Instance.new("TextLabel")
+    label.Text = text
     label.Font = Enum.Font.GothamBold
     label.TextScaled = true
     label.TextColor3 = Color3.new(1,1,1)
@@ -40,6 +45,7 @@ function DojoClient.hide()
     if gui then
         gui:Destroy()
         gui = nil
+        label = nil
     end
 end
 


### PR DESCRIPTION
## Summary
- let `DojoClient.start` accept an optional realm name and update the loading label accordingly
- pass human-friendly realm names from `BootUI` to `DojoClient.start`

## Testing
- `luac -p ReplicatedStorage/BootModules/DojoClient.lua ReplicatedStorage/BootModules/BootUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c12f0781d0833282532d6a466d779b