### PR TITLE
Centralize server-side currency deductions

### DIFF
--- a/ReplicatedStorage/BootModules/CurrencyService.lua
+++ b/ReplicatedStorage/BootModules/CurrencyService.lua
@@ -29,11 +29,9 @@ function CurrencyService:GetBalance()
 end
 
 function CurrencyService:AddCoins(amount)
-        self.coins = self.coins + amount
         if self.updateEvent then
-                self.updateEvent:FireServer({coins = self.coins})
+                self.updateEvent:FireServer({addCoins = amount})
         end
-        self.BalanceChanged:Fire(self.coins, self.orbs)
 end
 
 function CurrencyService:GetOrbCount()
@@ -57,12 +55,9 @@ function CurrencyService:AddOrb(element)
 end
 
 function CurrencyService:SpendCoins(amount)
-        if self.coins < amount then return false end
-        self.coins = self.coins - amount
         if self.updateEvent then
-                self.updateEvent:FireServer({coins = self.coins})
+                self.updateEvent:FireServer({spendCoins = amount})
         end
-        self.BalanceChanged:Fire(self.coins, self.orbs)
         return true
 end
 

--- a/ReplicatedStorage/BootModules/Shop.lua
+++ b/ReplicatedStorage/BootModules/Shop.lua
@@ -12,7 +12,8 @@ function Shop.new(config, currencyService)
 end
 
 function Shop:Purchase(itemId, cost)
-        if not self.currencyService:SpendCoins(cost) then
+        local coins = self.currencyService:GetBalance()
+        if coins < cost then
                 warn("Not enough coins for purchase")
                 return false
         end

--- a/ServerScriptService/AbilityService.server.lua
+++ b/ServerScriptService/AbilityService.server.lua
@@ -1,5 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+local CurrencyService = shared.CurrencyService
 
 local learnRF = Instance.new("RemoteFunction")
 learnRF.Name = "LearnAbility"
@@ -29,11 +30,17 @@ learnRF.OnServerInvoke = function(player, abilityName)
     if not prerequisitesMet(player, abilityName) then
         return false, "Missing prerequisites"
     end
-    local coins = player:FindFirstChild("leaderstats") and player.leaderstats:FindFirstChild("Coins")
-    if not coins or coins.Value < info.cost then
+    local cs = CurrencyService
+    if not cs then
+        return false, "Currency service unavailable"
+    end
+    local balance = cs.GetBalance(player)
+    if not balance or balance.coins < info.cost then
         return false, "Not enough currency"
     end
-    coins.Value -= info.cost
+    if not cs.AdjustCoins(player, -info.cost) then
+        return false, "Not enough currency"
+    end
     abilitiesFolder = abilitiesFolder or Instance.new("Folder")
     abilitiesFolder.Name = "Abilities"
     abilitiesFolder.Parent = player


### PR DESCRIPTION
## Summary
- Stop client coins from being altered during purchases and send purchase requests to the server
- Route ability learning coin costs through the shared CurrencyService
- Broadcast balance updates from the server and rely on them for UI updates

## Testing
- `luac -p ReplicatedStorage/BootModules/Shop.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c262afd2a88332acf970da131bf9f9