### PR TITLE
Add rebirth service and persist rebirth counts

### DIFF
--- a/ServerScriptService/RebirthService.lua
+++ b/ServerScriptService/RebirthService.lua
@@ -1,0 +1,19 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local rebirthEvent = ReplicatedStorage:FindFirstChild("RebirthEvent")
+if rebirthEvent and not rebirthEvent:IsA("RemoteEvent") then
+    rebirthEvent:Destroy()
+    rebirthEvent = nil
+end
+if not rebirthEvent then
+    rebirthEvent = Instance.new("RemoteEvent")
+    rebirthEvent.Name = "RebirthEvent"
+    rebirthEvent.Parent = ReplicatedStorage
+end
+
+local dataScript = script.Parent:WaitForChild("DataSavingScript")
+local rebirthFunction = dataScript:WaitForChild("RebirthFunction")
+
+rebirthEvent.OnServerEvent:Connect(function(player)
+    rebirthFunction:Invoke(player)
+end)


### PR DESCRIPTION
## Summary
- track per-player rebirth counts and expose them to scripts
- add RebirthService with remote event to trigger rebirths
- reset elements, abilities and element inventory on rebirth while preserving other progress

## Testing
- `apt-get install -y lua5.1` *(installs Lua for syntax checks)*
- `luac -p ServerScriptService/DataSavingScript.lua` *(fails: '=' expected near '+', due to Luau syntax)*
- `luac -p ServerScriptService/RebirthService.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c2649645988332a9bca9e89583b9fd