### PR TITLE
Track element levels from orbs

### DIFF
--- a/ServerScriptService/CurrencyService.server.lua
+++ b/ServerScriptService/CurrencyService.server.lua
@@ -9,24 +9,20 @@ if not updateEvent then
     updateEvent.Parent = ReplicatedStorage
 end
 
-local MAX_ORBS = 10
+local ORB_THRESHOLD = 10
 local balances = {}
+
+local sessionData = shared.sessionData or {}
 
 local CurrencyService = {balances = balances}
 shared.CurrencyService = CurrencyService
 
-local function getOrbCount(orbs)
-    local total = 0
-    for _, v in pairs(orbs) do
-        total += v
-    end
-    return total
-end
-
-local function sendBalance(player)
+local function sendBalance(player, leveled)
     local data = balances[player.UserId]
     if data then
-        updateEvent:FireClient(player, data)
+        local payload = {coins = data.coins, orbs = data.orbs, elements = data.elements}
+        if leveled then payload.elementLeveled = leveled end
+        updateEvent:FireClient(player, payload)
     end
 end
 
@@ -48,9 +44,9 @@ local function addOrb(player, element)
     local balance = balances[player.UserId]
     if not balance or typeof(element) ~= "string" then return end
     balance.orbs = balance.orbs or {}
-    if balance.orbs[element] then return end
-    if getOrbCount(balance.orbs) >= MAX_ORBS then return end
-    balance.orbs[element] = 1
+    balance.elements = balance.elements or {}
+    local count = (balance.orbs[element] or 0) + 1
+    balance.orbs[element] = count
 
     local invStr = player:GetAttribute("Inventory")
     local inv = {}
@@ -59,14 +55,36 @@ local function addOrb(player, element)
         if ok then inv = data end
     end
     inv.orbs = inv.orbs or {}
-    inv.orbs[element] = 1
+    inv.orbs[element] = count
+
+    local leveled
+    local sd = sessionData[player.UserId]
+    if sd then
+        sd.elements = sd.elements or {}
+        local levels = math.floor(count / ORB_THRESHOLD)
+        if levels > 0 then
+            sd.elements[element] = (sd.elements[element] or 0) + levels
+            balance.elements[element] = sd.elements[element]
+            count = count % ORB_THRESHOLD
+            balance.orbs[element] = count
+            inv.orbs[element] = count
+            leveled = element
+        else
+            balance.elements[element] = sd.elements[element] or 0
+        end
+    end
+
     player:SetAttribute("Inventory", HttpService:JSONEncode(inv))
 
-    sendBalance(player)
+    sendBalance(player, leveled)
 end
 
 Players.PlayerAdded:Connect(function(player)
-    balances[player.UserId] = {coins = 0, orbs = {}}
+    local sd = sessionData[player.UserId]
+    if not sd then
+        repeat task.wait() sd = sessionData[player.UserId] until sd
+    end
+    balances[player.UserId] = {coins = 0, orbs = {}, elements = sd and sd.elements or {}}
     sendBalance(player)
     player:GetAttributeChangedSignal("Inventory"):Connect(function()
         local invStr = player:GetAttribute("Inventory")
@@ -87,7 +105,7 @@ end)
 updateEvent.OnServerEvent:Connect(function(player, data)
     local balance = balances[player.UserId]
     if not balance then
-        balance = {coins = 0, orbs = {}}
+        balance = {coins = 0, orbs = {}, elements = {}}
         balances[player.UserId] = balance
     end
     if typeof(data) == "table" then

--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -60,6 +60,7 @@ local DEFAULT_DATA = {
 }
 
 local sessionData = {}
+shared.sessionData = sessionData
 
 local rebirthFunction = Instance.new("BindableFunction")
 rebirthFunction.Name = "RebirthFunction"
@@ -79,7 +80,7 @@ local function deepCopy(tbl)
     return copy
 end
 
--- Ensure orbs table is a dictionary with a total not exceeding 10
+-- Ensure orbs table is a dictionary; limit total to 10 to match inventory size
 local function sanitizeOrbs(orbs)
     orbs = typeof(orbs) == "table" and orbs or {}
     local total = 0
@@ -91,6 +92,16 @@ local function sanitizeOrbs(orbs)
             cleaned[element] = allowed
             total += allowed
         end
+    end
+    return cleaned
+end
+
+-- Ensure elements table only contains numbers for known elements
+local function sanitizeElements(elements)
+    elements = typeof(elements) == "table" and elements or {}
+    local cleaned = {}
+    for element, _ in pairs(DEFAULT_DATA.elements) do
+        cleaned[element] = tonumber(elements[element]) or 0
     end
     return cleaned
 end
@@ -115,6 +126,7 @@ local function loadPlayerData(player)
     if success then
         data = data or deepCopy(DEFAULT_DATA)
         fillMissing(data, DEFAULT_DATA)
+        data.elements = sanitizeElements(data.elements)
         data.slots = typeof(data.slots) == "table" and data.slots or {}
         local slotData = data.slots["1"]
         if not slotData then
@@ -163,6 +175,7 @@ local function savePlayerData(player)
     data.slots[tostring(slot)].unlockedRealms = data.unlockedRealms
     data.slots[tostring(slot)].rebirths = data.rebirths
 
+    data.elements = sanitizeElements(data.elements)
     local success, err = pcall(function()
         DataStore:SetAsync(key, data)
     end)


### PR DESCRIPTION
## Summary
- Track elemental progression on the server by mapping orbs to elements and leveling up when collecting 10
- Persist element levels in player saves and surface to clients via CurrencyUpdated
- Display element levels in the boot UI and update client currency service

## Testing
- `apt-get update` *(fails to fetch some indices but continues)*
- `apt-get install -y lua5.1`
- `luac -p ServerScriptService/DataSavingScript.lua` *(fails: '=' expected near '+')*
- `luac -p ServerScriptService/CurrencyService.server.lua` *(fails: '=' expected near '+')*


------
https://chatgpt.com/codex/tasks/task_e_68c26bc67f608332a6dc83d500f96c1a