### PR TITLE
Add shop item configuration and purchase handling

### DIFF
--- a/ReplicatedStorage/BootModules/ShopItems.lua
+++ b/ReplicatedStorage/BootModules/ShopItems.lua
@@ -1,0 +1,12 @@
+local ShopItems = {
+    Elements = {
+        Fire = {cost = 100},
+        Beast = {cost = 150}
+    },
+    Weapons = {
+        ["Sword A"] = {cost = 200, assetId = 16232452668},
+        ["Bow A"] = {cost = 150, assetId = 16117888680}
+    }
+}
+
+return ShopItems

--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -1,5 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+local ShopItems = require(ReplicatedStorage:WaitForChild("BootModules"):WaitForChild("ShopItems"))
 
 local ShopUI = {}
 
@@ -80,20 +81,33 @@ function ShopUI.init(config, shop, bootUI, defaultTab)
         end)
     end
 
-    -- Placeholder tabs
-    local elementsLabel = Instance.new("TextLabel")
-    elementsLabel.Size = UDim2.new(1,0,0,40)
-    elementsLabel.BackgroundTransparency = 1
-    elementsLabel.Text = "Elements coming soon"
-    elementsLabel.TextColor3 = Color3.new(1,1,1)
-    elementsLabel.Parent = tabFrames["Elements"]
+    -- Elements tab
+    local elementsFrame = tabFrames["Elements"]
+    for itemId, info in pairs(ShopItems.Elements) do
+        local btn = Instance.new("TextButton")
+        btn.Size = UDim2.new(1,0,0,40)
+        btn.BackgroundColor3 = Color3.fromRGB(80,80,82)
+        btn.TextColor3 = Color3.new(1,1,1)
+        btn.Text = itemId .. " (" .. info.cost .. " Coins)"
+        btn.Parent = elementsFrame
+        btn.Activated:Connect(function()
+            shop:Purchase(itemId, info.cost)
+        end)
+    end
 
-    local weaponsLabel = Instance.new("TextLabel")
-    weaponsLabel.Size = UDim2.new(1,0,0,40)
-    weaponsLabel.BackgroundTransparency = 1
-    weaponsLabel.Text = "Weapons coming soon"
-    weaponsLabel.TextColor3 = Color3.new(1,1,1)
-    weaponsLabel.Parent = tabFrames["Weapons"]
+    -- Weapons tab
+    local weaponsFrame = tabFrames["Weapons"]
+    for itemId, info in pairs(ShopItems.Weapons) do
+        local btn = Instance.new("TextButton")
+        btn.Size = UDim2.new(1,0,0,40)
+        btn.BackgroundColor3 = Color3.fromRGB(80,80,82)
+        btn.TextColor3 = Color3.new(1,1,1)
+        btn.Text = itemId .. " (" .. info.cost .. " Coins)"
+        btn.Parent = weaponsFrame
+        btn.Activated:Connect(function()
+            shop:Purchase(itemId, info.cost)
+        end)
+    end
 
     function ShopUI.setTab(tabName)
         for name, f in pairs(tabFrames) do


### PR DESCRIPTION
## Summary
- List purchasable Elements and Weapons with costs in the shop UI
- Add shared ShopItems config module for item definitions
- Handle ShopEvent on the server to deduct coins and deliver items

## Testing
- `luac -p ReplicatedStorage/BootModules/ShopItems.lua ReplicatedStorage/BootModules/ShopUI.lua ServerScriptService/ShopScript.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c26dafc3708332b891742f2a4b785d