### PR TITLE
Handle locked realm buttons

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -45,6 +45,10 @@ local ShopUI          = require(ReplicatedStorage.BootModules.ShopUI)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
 local DojoClient      = require(ReplicatedStorage.BootModules.DojoClient)
 
+function BootUI.unlockRealm(name)
+    TeleportClient.unlockRealm(name)
+end
+
 local currencyService
 local backpackData
 local currentTab = "Main"


### PR DESCRIPTION
## Summary
- populate `worldSpawnIds` with real place IDs and add realm unlocking helper
- disable world buttons for locked realms and notify when selecting locked realm
- expose `BootUI.unlockRealm` for UIs to unlock realms

## Testing
- `luacheck ReplicatedStorage/ClientModules/TeleportClient.lua ReplicatedStorage/BootModules/BootUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_68c26fda2ec883328d8558979d6d8983