### PR TITLE
Fix BootUI backpack update timing

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -70,6 +70,18 @@ local shop            = Shop.new(config, currencyService)
 BootUI.currencyService = currencyService
 BootUI.shop = shop
 
+    -- connect currency updates after service is created but before backpack UI is defined
+    local renderBackpack
+    currencyService.BalanceChanged.Event:Connect(function(coins, orbs, elements)
+        backpackData = backpackData or {}
+        backpackData.coins = coins
+        backpackData.orbs = orbs
+        backpackData.elements = elements
+        if renderBackpack then
+            renderBackpack(currentTab)
+        end
+    end)
+
 -- =====================
 -- Config
 -- =====================
@@ -86,13 +98,6 @@ local StarterBackpack = config.inventory or config.starterBackpack or {
 BootUI.StarterBackpack = StarterBackpack
 BootUI.personaData = config.personaData
 
-    currencyService.BalanceChanged.Event:Connect(function(coins, orbs, elements)
-        backpackData = backpackData or {}
-        backpackData.coins = coins
-        backpackData.orbs = orbs
-        backpackData.elements = elements
-        renderBackpack(currentTab)
-    end)
 
 -- =====================
 -- Camera helpers (world)
@@ -722,7 +727,7 @@ local function updateTabButtonStates()
     end
 end
 
-local function renderBackpack(tab)
+    function renderBackpack(tab)
     if backpackData == nil then return end
     currentTab = tab or currentTab
     updateTabButtonStates()
@@ -792,11 +797,11 @@ for name,btn in pairs(tabButtons) do
     end)
 end
 
-function BootUI.populateBackpackUI(bp)
-    backpackData = bp
-    backpackData.elements = currencyService and currencyService.elements or backpackData.elements
-    renderBackpack(currentTab)
-end
+    function BootUI.populateBackpackUI(bp)
+        backpackData = bp
+        backpackData.elements = currencyService and currencyService.elements or backpackData.elements
+        renderBackpack(currentTab)
+    end
 
 -- =====================
 btnBack.MouseButton1Click:Connect(function()


### PR DESCRIPTION
## Summary
- connect CurrencyService updates early and defer backpack rendering until the render function exists

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c2723723788332805c692bc8d5778b