### PR TITLE
Use WaitForChild for ShopItems and add fallback

### DIFF
--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -1,11 +1,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
 if not shopItemsModule then
     warn("ShopItems module missing")
+    return {}
 end
-local ShopItems = shopItemsModule and require(shopItemsModule) or {Elements = {}, Weapons = {}}
+local ShopItems = require(shopItemsModule)
 
 local ShopUI = {}
 

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -9,11 +9,12 @@ if not shopEvent then
 end
 
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
 if not shopItemsModule then
     warn("ShopItems module missing")
+    return
 end
-local ShopItems = shopItemsModule and require(shopItemsModule) or {}
+local ShopItems = require(shopItemsModule)
 local CurrencyService = shared.CurrencyService
 
 local function findItem(itemId)


### PR DESCRIPTION
## Summary
- Use `WaitForChild` when loading ShopItems module so it exists before requiring
- Warn and halt initialization if ShopItems is missing

## Testing
- `luac -p ServerScriptService/ShopScript.lua ReplicatedStorage/BootModules/ShopUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_68c277d44a508332b87384540d537c1e