### PR TITLE
feat: add merch booth stub module

### DIFF
--- a/ReplicatedStorage/MerchBooth.lua
+++ b/ReplicatedStorage/MerchBooth.lua
@@ -1,0 +1,24 @@
+local MerchBooth = {}
+
+-- Toggles the catalog button visibility.
+function MerchBooth.toggleCatalogButton(_enabled)
+    -- no-op stub
+end
+
+-- Accepts configuration options for the booth.
+function MerchBooth.configure(_options)
+    -- no-op stub
+end
+
+-- Opens the merch booth interface.
+function MerchBooth.openMerchBooth()
+    -- no-op stub
+end
+
+-- Closes the merch booth interface.
+function MerchBooth.closeMerchBooth()
+    -- no-op stub
+end
+
+return MerchBooth
+


### PR DESCRIPTION
## Summary
- add placeholder MerchBooth module so existing calls succeed

## Testing
- `luac -p ReplicatedStorage/MerchBooth.lua`
- `lua -e 'package.path="./?.lua;./?/init.lua;"..package.path; require("ReplicatedStorage/MerchBooth")'`


------
https://chatgpt.com/codex/tasks/task_e_68c2786c6d048332ba8137216a35a9f2