### PR TITLE
Add teleport UI placeholders and safe init

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -224,7 +224,49 @@ BootUI.shopBtn = shopBtn
 shopBtn.Activated:Connect(function()
     toggleShop()
 end)
-TeleportClient.init(root)
+
+    -- teleport UI placeholders
+    local teleFrame = Instance.new("Frame")
+    teleFrame.Name = "TeleFrame"
+    teleFrame.Size = UDim2.fromScale(1,1)
+    teleFrame.BackgroundTransparency = 1
+    teleFrame.Visible = false
+    teleFrame.Parent = root
+
+    local zoneButtons = {"Atom","Fire","Grow","Ice","Light","Metal","Water","Wind","Dojo","Starter"}
+    for _, zone in ipairs(zoneButtons) do
+        local button = Instance.new("TextButton")
+        button.Name = zone .. "Button"
+        button.Size = UDim2.new(0,0,0,0)
+        button.Visible = false
+        button.Text = zone
+        button.Parent = teleFrame
+    end
+
+    local worldFrame = Instance.new("Frame")
+    worldFrame.Name = "WorldTeleFrame"
+    worldFrame.Size = UDim2.fromScale(1,1)
+    worldFrame.BackgroundTransparency = 1
+    worldFrame.Visible = false
+    worldFrame.Parent = root
+
+    local enterRealmButton = Instance.new("TextButton")
+    enterRealmButton.Name = "EnterRealmButton"
+    enterRealmButton.Size = UDim2.new(0,0,0,0)
+    enterRealmButton.Visible = false
+    enterRealmButton.Text = "Enter"
+    enterRealmButton.Parent = worldFrame
+
+    for realmName, _ in pairs(TeleportClient.worldSpawnIds) do
+        local button = Instance.new("TextButton")
+        button.Name = realmName .. "Button"
+        button.Size = UDim2.new(0,0,0,0)
+        button.Visible = false
+        button.Text = realmName
+        button.Parent = worldFrame
+    end
+
+    TeleportClient.init(root)
 
 -- Intro visuals
 local fade = Instance.new("Frame")

--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -218,8 +218,12 @@ function TeleportClient.init(gui)
                 return
         end
 
-        TeleportClient.bindZoneButtons(gui)
-        TeleportClient.bindWorldButtons(gui)
+        if gui:FindFirstChild("TeleFrame", true) then
+                TeleportClient.bindZoneButtons(gui)
+        end
+        if gui:FindFirstChild("WorldTeleFrame", true) then
+                TeleportClient.bindWorldButtons(gui)
+        end
 end
 
 return TeleportClient


### PR DESCRIPTION
## Summary
- Add TeleFrame and WorldTeleFrame placeholders with expected buttons in BootUI
- Initialize TeleportClient only after teleport frames exist
- Guard TeleportClient.init to bind buttons only when frames are present

## Testing
- `selene ./ReplicatedStorage/BootModules/BootUI.lua` *(fails: command not found)*
- `luau-analyze ReplicatedStorage/BootModules/BootUI.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c27929247c83328d1859ef54294cf8