### PR TITLE
Ensure safe blur effect handling

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -157,21 +157,37 @@ local function tweenToEnd()
 end
 BootUI.tweenToEnd = tweenToEnd
 
--- =====================
 -- Lighting helpers (disable DOF while UI is visible)
 -- =====================
-local savedDOF = nil
+local savedDOF
+local savedBlurEnabled
 local function disableUIBlur()
-    if savedDOF then return end
+    if savedDOF or savedBlurEnabled ~= nil then return end
     savedDOF = {}
     for _,e in ipairs(Lighting:GetChildren()) do
-        if e:IsA("DepthOfFieldEffect") then savedDOF[e] = e.Enabled; e.Enabled = false end
+        if e:IsA("DepthOfFieldEffect") then
+            savedDOF[e] = e.Enabled
+            e.Enabled = false
+        end
+    end
+    local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+    if blur then
+        savedBlurEnabled = blur.Enabled
+        blur.Enabled = false
     end
 end
 local function restoreUIBlur()
-    if not savedDOF then return end
-    for e,was in pairs(savedDOF) do if e and e.Parent then e.Enabled = was end end
-    savedDOF = nil
+    if savedDOF then
+        for e,was in pairs(savedDOF) do
+            if e and e.Parent then e.Enabled = was end
+        end
+        savedDOF = nil
+    end
+    if savedBlurEnabled ~= nil then
+        local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+        if blur then blur.Enabled = savedBlurEnabled end
+        savedBlurEnabled = nil
+    end
 end
 
 -- =====================

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -1,6 +1,16 @@
 -- Client bootstrap script loading BootModules
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Lighting = game:GetService("Lighting")
 local BootModules = ReplicatedStorage:WaitForChild("BootModules")
+
+-- Ensure a BlurEffect exists so other scripts can safely toggle it
+local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+if not blur then
+    blur = Instance.new("BlurEffect")
+    blur.Name = "Blur"
+    blur.Enabled = false
+    blur.Parent = Lighting
+end
 
 local PersonaUI = require(BootModules:WaitForChild("PersonaUI"))
 PersonaUI.start()


### PR DESCRIPTION
## Summary
- Initialize a Lighting blur effect on client startup so UI scripts can toggle it safely
- Guard UI blur helpers by locating the BlurEffect via `FindFirstChild`

## Testing
- `luac -p StarterPlayer/StarterPlayerScripts/Boot.client.lua ReplicatedStorage/BootModules/BootUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c27b7a1fb08332a02bb00c74a437d4