### PR TITLE
Ensure ShopItems module waits indefinitely

### DIFF
--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -1,11 +1,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
-if not shopItemsModule then
-    warn("ShopItems module missing")
-    return {}
-end
+local shopItemsModule = bootModules:WaitForChild("ShopItems")
+assert(shopItemsModule, "ShopItems module missing")
 local ShopItems = require(shopItemsModule)
 
 local ShopUI = {}

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -9,11 +9,8 @@ if not shopEvent then
 end
 
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
-if not shopItemsModule then
-    warn("ShopItems module missing")
-    return
-end
+local shopItemsModule = bootModules:WaitForChild("ShopItems")
+assert(shopItemsModule, "ShopItems module missing")
 local ShopItems = require(shopItemsModule)
 local CurrencyService = shared.CurrencyService
 


### PR DESCRIPTION
## Summary
- remove 5-second replication timeout when retrieving ShopItems module in server and client
- add assertions to log clear errors if ShopItems is missing

## Testing
- `luacheck ServerScriptService/ShopScript.lua ReplicatedStorage/BootModules/ShopUI.lua` *(command not found: luacheck)*
- `apt-get install -y luacheck` *(unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68c27efac24c8332af8d8cf5b4d2e280