### PR TITLE
Gracefully handle missing ShopItems module

### DIFF
--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -2,7 +2,10 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 local shopItemsModule = bootModules:WaitForChild("ShopItems")
-assert(shopItemsModule, "ShopItems module missing")
+if not shopItemsModule then
+    warn("ShopItems module missing")
+    return
+end
 local ShopItems = require(shopItemsModule)
 
 local ShopUI = {}

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -10,7 +10,10 @@ end
 
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 local shopItemsModule = bootModules:WaitForChild("ShopItems")
-assert(shopItemsModule, "ShopItems module missing")
+if not shopItemsModule then
+    warn("ShopItems module missing")
+    return
+end
 local ShopItems = require(shopItemsModule)
 local CurrencyService = shared.CurrencyService
 


### PR DESCRIPTION
## Summary
- warn and return when ShopItems module is absent in ShopUI and ShopScript

## Testing
- `luacheck ReplicatedStorage/BootModules/ShopUI.lua ServerScriptService/ShopScript.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c282c469888332a5cca84ce01385d1