### PR TITLE
feat: register merch booth items

### DIFF
--- a/ReplicatedStorage/MerchBooth.lua
+++ b/ReplicatedStorage/MerchBooth.lua
@@ -1,5 +1,12 @@
 local MerchBooth = {}
 
+MerchBooth.items = {}
+
+function MerchBooth.addItemAsync(assetId)
+    table.insert(MerchBooth.items, assetId)
+    -- Optionally fetch product info via MarketplaceService here
+end
+
 -- Toggles the catalog button visibility.
 function MerchBooth.toggleCatalogButton(_enabled)
     -- no-op stub
@@ -18,6 +25,10 @@ end
 -- Closes the merch booth interface.
 function MerchBooth.closeMerchBooth()
     -- no-op stub
+end
+
+function MerchBooth.getItems()
+    return MerchBooth.items
 end
 
 return MerchBooth

--- a/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
@@ -1,0 +1,15 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local MerchBooth = require(ReplicatedStorage:WaitForChild("MerchBooth"))
+
+local items = {
+    -- Asset IDs to display in the booth
+}
+
+for _, assetId in ipairs(items) do
+    local ok, err = pcall(function()
+        MerchBooth.addItemAsync(assetId)
+    end)
+    if not ok then
+        warn(string.format("Failed to add merch item %s: %s", assetId, err))
+    end
+end


### PR DESCRIPTION
## Summary
- add item storage and async add method to `MerchBooth`
- expose `getItems` and new `MerchBooth.client.lua` to populate booth items with error handling

## Testing
- `luac -p ReplicatedStorage/MerchBooth.lua StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c282d04f488332b54660ac37dc0a06