### PR TITLE
Bind teleport buttons after UI frame creation

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -282,7 +282,8 @@ end)
         button.Parent = worldFrame
     end
 
-    TeleportClient.init(root)
+    TeleportClient.bindZoneButtons(root)
+    TeleportClient.bindWorldButtons(root)
 
 -- Intro visuals
 local fade = Instance.new("Frame")


### PR DESCRIPTION
## Summary
- ensure TeleFrame and WorldTeleFrame exist with zone and realm buttons
- bind teleport zone/world buttons only after frames are inserted

## Testing
- `luac -p ReplicatedStorage/BootModules/BootUI.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c282d129108332ae05f5b10892ea65