### PR TITLE
Refine debug input logging and ignored keys

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -138,6 +138,15 @@ local ignoredInputKeys = {
         [Enum.KeyCode.D] = true,
         [Enum.KeyCode.Space] = true,
         [Enum.KeyCode.LeftShift] = true,
+        -- Arrow keys
+        [Enum.KeyCode.Up] = true,
+        [Enum.KeyCode.Down] = true,
+        [Enum.KeyCode.Left] = true,
+        [Enum.KeyCode.Right] = true,
+        -- Common UI navigation keys
+        [Enum.KeyCode.Tab] = true,
+        [Enum.KeyCode.Escape] = true,
+        [Enum.KeyCode.Return] = true,
 }
 
 -- Toggle to enable logging of raw and unmapped key presses for debugging.
@@ -156,30 +165,26 @@ UserInputService.InputBegan:Connect(function(input, gameProcessed)
 
         if gameProcessed then return end
 
-        if debugInputLogging and not ignoredInputKeys[input.KeyCode] then
-                print("?? Raw KeyCode input:", input.KeyCode.Name)
-        end
-
         if abilityKeybinds[input.KeyCode] then
                 print("Triggering ability for:", input.KeyCode.Name)
                 abilityKeybinds[input.KeyCode]()
                 return
         end
 
-	if combatKeybinds[input.KeyCode] then
-		local action = combatKeybinds[input.KeyCode]
-		print("Triggering combat action for:", action)
-		if not CombatController or not CombatController.perform then
-			warn("CombatController or perform method is nil!")
-			return
-		end
-		print("Calling CombatController.perform with:", action)
-		CombatController.perform(action)
-		return
-	end
+        if combatKeybinds[input.KeyCode] then
+                local action = combatKeybinds[input.KeyCode]
+                print("Triggering combat action for:", action)
+                if not CombatController or not CombatController.perform then
+                        warn("CombatController or perform method is nil!")
+                        return
+                end
+                print("Calling CombatController.perform with:", action)
+                CombatController.perform(action)
+                return
+        end
 
         if debugInputLogging and not ignoredInputKeys[input.KeyCode] then
-                warn("Key pressed but no action mapped:", input.KeyCode.Name)
+                print("Unmapped key pressed:", input.KeyCode.Name)
         end
 end)
 


### PR DESCRIPTION
## Summary
- expand ignored input key list to skip arrow keys and common UI navigation keys
- keep debug input logging opt-in via F8 toggle
- downgrade "no action mapped" warning to a simple debug print to avoid duplication

## Testing
- `luac -p StarterPlayer/StarterPlayerScripts/MainLocalScript.lua` *(fails: `)` expected near ':'; Luau syntax unsupported by luac)*


------
https://chatgpt.com/codex/tasks/task_e_68c282d1f9a4833282e69f0c64637e05