### PR TITLE
Ensure blur effect exists and is safely toggled

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -161,6 +161,16 @@ BootUI.tweenToEnd = tweenToEnd
 -- =====================
 local savedDOF
 local savedBlurEnabled
+local function getOrCreateBlur()
+    local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+    if not blur then
+        blur = Instance.new("BlurEffect")
+        blur.Name = "Blur"
+        blur.Enabled = false
+        blur.Parent = Lighting
+    end
+    return blur
+end
 local function disableUIBlur()
     if savedDOF or savedBlurEnabled ~= nil then return end
     savedDOF = {}
@@ -170,7 +180,7 @@ local function disableUIBlur()
             e.Enabled = false
         end
     end
-    local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+    local blur = getOrCreateBlur()
     if blur then
         savedBlurEnabled = blur.Enabled
         blur.Enabled = false
@@ -184,7 +194,7 @@ local function restoreUIBlur()
         savedDOF = nil
     end
     if savedBlurEnabled ~= nil then
-        local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+        local blur = getOrCreateBlur()
         if blur then blur.Enabled = savedBlurEnabled end
         savedBlurEnabled = nil
     end


### PR DESCRIPTION
## Summary
- Safely create and reuse Lighting's BlurEffect
- Guard blur toggling to avoid runtime errors

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c282d321948332be49d45312361b8a