### PR TITLE
Handle missing ShopItems module gracefully

### DIFF
--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -1,12 +1,17 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
-if not shopItemsModule then
+
+-- Try to load the ShopItems module but fall back to an empty table so the
+-- shop UI can still be created even if the module is missing. Returning nil
+-- from this module would cause requires to fail in BootUI.
+local ShopItems = {Elements = {}, Weapons = {}}
+local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+if shopItemsModule then
+    ShopItems = require(shopItemsModule)
+else
     warn("ShopItems module missing")
-    return
 end
-local ShopItems = require(shopItemsModule)
 
 local ShopUI = {}
 

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -9,12 +9,16 @@ if not shopEvent then
 end
 
 local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
-if not shopItemsModule then
+
+-- Load ShopItems if available; otherwise continue with an empty list so the
+-- server script doesn't abort during startup.
+local ShopItems = {}
+local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+if shopItemsModule then
+    ShopItems = require(shopItemsModule)
+else
     warn("ShopItems module missing")
-    return
 end
-local ShopItems = require(shopItemsModule)
 local CurrencyService = shared.CurrencyService
 
 local function findItem(itemId)


### PR DESCRIPTION
## Summary
- ensure ShopUI falls back to an empty items table when ShopItems module is absent
- allow server ShopScript to start even if ShopItems module isn't found

## Testing
- `luacheck ReplicatedStorage/BootModules/ShopUI.lua ServerScriptService/ShopScript.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c8a8b0648332af2f6cfe56216eb2