### PR TITLE
fix: ensure ShopItems module loads

### DIFF
--- a/ReplicatedStorage/BootModules/ShopUI.lua
+++ b/ReplicatedStorage/BootModules/ShopUI.lua
@@ -6,7 +6,7 @@ local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 -- shop UI can still be created even if the module is missing. Returning nil
 -- from this module would cause requires to fail in BootUI.
 local ShopItems = {Elements = {}, Weapons = {}}
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -13,7 +13,7 @@ local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 -- Load ShopItems if available; otherwise continue with an empty list so the
 -- server script doesn't abort during startup.
 local ShopItems = {}
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else


### PR DESCRIPTION
## Summary
- wait for `ShopItems` module before requiring in `ShopScript`
- wait for `ShopItems` module in `ShopUI` to avoid startup warnings

## Testing
- `luacheck ServerScriptService/ShopScript.lua ReplicatedStorage/BootModules/ShopUI.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c3de79856c833286eaa4597fb76ef0