### PR TITLE
Replace placeholder sound with generic beep

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -21,7 +21,7 @@ local PlayerGui = player:WaitForChild("PlayerGui")
 -- Purge placeholder sounds before preloading
 for _, descendant in ipairs(SoundService:GetDescendants()) do
     if descendant:IsA("Sound") and descendant.SoundId:match("rbxassetid://0") then
-        descendant:Destroy()
+        descendant.SoundId = "rbxassetid://184586547" -- Generic placeholder beep
     end
 end
 


### PR DESCRIPTION
## Summary
- replace `rbxassetid://0` placeholder sounds with a generic beep sound so they load without errors

## Testing
- `rojo build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e0bf1d108332952d50ca1280d29f