### PR TITLE
Replace invalid sound asset in main script

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -21,7 +21,8 @@ local PlayerGui = player:WaitForChild("PlayerGui")
 -- Purge placeholder sounds before preloading
 for _, descendant in ipairs(SoundService:GetDescendants()) do
     if descendant:IsA("Sound") and descendant.SoundId:match("rbxassetid://0") then
-        descendant.SoundId = "rbxassetid://184586547" -- Generic placeholder beep
+        -- Replace placeholder/invalid sound IDs with a valid asset
+        descendant.SoundId = "rbxassetid://81165228663280"
     end
 end
 


### PR DESCRIPTION
## Summary
- fix placeholder sound by replacing invalid SoundId with working asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e591ab1c8332b8875e7ae33c1a39