### PR TITLE
Remove WaitForChild and profile remote calls

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -15,14 +15,21 @@ local Lighting          = game:GetService("Lighting")
 local HttpService       = game:GetService("HttpService")
 
 local player  = Players.LocalPlayer
-local rf      = ReplicatedStorage:WaitForChild("PersonaServiceRF")
+local rf      = ReplicatedStorage.PersonaServiceRF
 local cam     = Workspace.CurrentCamera
 local enterRE = ReplicatedStorage:FindFirstChild("EnterDojoRE") -- created by server script
 
 local topInsetY = GuiService:GetGuiInset().Y
 
+local function profileRF(action, data)
+    local start = os.clock()
+    local result = rf:InvokeServer(action, data)
+    warn(string.format("PersonaServiceRF:%s took %.3fs", tostring(action), os.clock() - start))
+    return result
+end
+
 function BootUI.fetchData()
-    local persona = rf:InvokeServer("get", {}) or {}
+    local persona = profileRF("get", {}) or {}
     local inventory
     local invStr = player:GetAttribute("Inventory")
     if typeof(invStr) == "string" then
@@ -41,9 +48,9 @@ end
 local Cosmetics       = require(ReplicatedStorage.BootModules.Cosmetics)
 local CurrencyService = require(ReplicatedStorage.BootModules.CurrencyService)
 local Shop            = require(ReplicatedStorage.BootModules.Shop)
-local ShopUI          = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("UI"):WaitForChild("ShopUI"))
-local QuestUI         = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("UI"):WaitForChild("QuestUI"))
-local BackpackUI      = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("UI"):WaitForChild("BackpackUI"))
+local ShopUI          = require(ReplicatedStorage.ClientModules.UI.ShopUI)
+local QuestUI         = require(ReplicatedStorage.ClientModules.UI.QuestUI)
+local BackpackUI      = require(ReplicatedStorage.ClientModules.UI.BackpackUI)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
 local DojoClient      = require(ReplicatedStorage.BootModules.DojoClient)
 
@@ -98,7 +105,7 @@ BootUI.personaData = config.personaData
 -- =====================
 -- Camera helpers (world)
 -- =====================
-local camerasFolder = Workspace:WaitForChild("Cameras", 5)
+local camerasFolder = Workspace:FindFirstChild("Cameras")
 local startPos      = camerasFolder and camerasFolder:FindFirstChild("startPos")
 local endPos        = camerasFolder and camerasFolder:FindFirstChild("endPos")
 
@@ -204,7 +211,7 @@ ui.ResetOnSpawn   = false
 ui.Name           = "IntroGui"
 ui.IgnoreGuiInset = true
 ui.DisplayOrder   = 100
-ui.Parent         = player:WaitForChild("PlayerGui")
+ui.Parent         = player.PlayerGui
 
 local root = Instance.new("Frame")
 root.Size = UDim2.fromScale(1,1)
@@ -386,7 +393,7 @@ local realmInfo = {
 local realmDisplayLookup = {}
 for _,info in ipairs(realmInfo) do realmDisplayLookup[info.key] = info.name end
 
-local realmsFolder = player:FindFirstChild("Realms") or player:WaitForChild("Realms",5)
+local realmsFolder = player:FindFirstChild("Realms")
 
 local function updateRealmButton(key)
     local btn = realmButtons[key]

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -6,7 +6,13 @@ local TweenService = game:GetService("TweenService")
 local HttpService = game:GetService("HttpService")
 local ContentProvider = game:GetService("ContentProvider")
 
-local rf = ReplicatedStorage:WaitForChild("PersonaServiceRF")
+local rf = ReplicatedStorage.PersonaServiceRF
+local function profileRF(action, data)
+    local start = os.clock()
+    local result = rf:InvokeServer(action, data)
+    warn(string.format("PersonaServiceRF:%s took %.3fs", tostring(action), os.clock() - start))
+    return result
+end
 local player = Players.LocalPlayer
 
 local dojo
@@ -193,7 +199,7 @@ local function updateSlots()
 					if not ui.clearConn then
 						ui.clearConn = ui.clearBtn.MouseButton1Click:Connect(function()
 							showConfirm(("Clear slot %d?"):format(index), function()
-                                                                local res = rf:InvokeServer("clear", {slot = index})
+                                                                local res = profileRF("clear", {slot = index})
                                                                 if res and res.ok then
                                                                         if chosenSlot == index then chosenSlot = nil end
                                                                         refreshSlots(res)
@@ -684,7 +690,7 @@ function Cosmetics.init(config, root, bootUI)
 	for i,entry in pairs(slotButtons) do
 		local index = i
                entry.useBtn.MouseButton1Click:Connect(function()
-                        local result = rf:InvokeServer("use", {slot = index})
+                        local result = profileRF("use", {slot = index})
                         if not (result and result.ok) then warn("Use slot failed:", result and result.err) return end
                         chosenSlot = index
                         currentChoiceType = result.persona and result.persona.type or currentChoiceType
@@ -693,10 +699,10 @@ function Cosmetics.init(config, root, bootUI)
                         showLoadout(result.persona and result.persona.type or currentChoiceType)
                 end)
                entry.robloxBtn.MouseButton1Click:Connect(function()
-                        local res = rf:InvokeServer("save", {slot = index, type = "Roblox"})
+                        local res = profileRF("save", {slot = index, type = "Roblox"})
                         if res and res.ok then
                                 refreshSlots(res)
-                                local useRes = rf:InvokeServer("use", {slot = index})
+                                local useRes = profileRF("use", {slot = index})
                                 if useRes and useRes.ok then
                                         chosenSlot = index
                                         currentChoiceType = "Roblox"
@@ -711,10 +717,10 @@ function Cosmetics.init(config, root, bootUI)
                         end
                 end)
                entry.starterBtn.MouseButton1Click:Connect(function()
-                        local res = rf:InvokeServer("save", {slot = index, type = "Ninja"})
+                        local res = profileRF("save", {slot = index, type = "Ninja"})
                         if res and res.ok then
                                 refreshSlots(res)
-                                local useRes = rf:InvokeServer("use", {slot = index})
+                                local useRes = profileRF("use", {slot = index})
                                 if useRes and useRes.ok then
                                         chosenSlot = index
                                         currentChoiceType = "Ninja"

--- a/ReplicatedStorage/BootModules/DojoClient.lua
+++ b/ReplicatedStorage/BootModules/DojoClient.lua
@@ -18,7 +18,7 @@ function DojoClient.start(realmName)
     gui.IgnoreGuiInset = true
     gui.ResetOnSpawn = false
     gui.DisplayOrder = 200
-    gui.Parent = player:WaitForChild("PlayerGui")
+    gui.Parent = player.PlayerGui
 
     local root = Instance.new("Frame")
     root.Size = UDim2.fromScale(1,1)

--- a/ReplicatedStorage/BootModules/PersonaUI.lua
+++ b/ReplicatedStorage/BootModules/PersonaUI.lua
@@ -19,7 +19,7 @@ function PersonaUI.start(config)
     gui.Name           = "IntroGui"
     gui.IgnoreGuiInset = true
     gui.DisplayOrder   = 100
-    gui.Parent         = player:WaitForChild("PlayerGui")
+    gui.Parent         = player.PlayerGui
 
     local root = Instance.new("Frame")
     root.Size = UDim2.fromScale(1,1)
@@ -82,17 +82,28 @@ function PersonaUI.start(config)
         ContentProvider:PreloadAsync(items)
     end)
 
-    bar.Size = UDim2.new(0,0,0.01,0)
-    TweenService:Create(bar, TweenInfo.new(1.6, Enum.EasingStyle.Quad), {Size = UDim2.new(0.6,0,0.01,0)}):Play()
-    wait(1.65)
+    local loadTime = config.waitTime
+    if loadTime == nil then loadTime = 1.65 end
+    local fadeTime = config.fadeTime
+    if fadeTime == nil then fadeTime = 0.25 end
 
-    local t = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
-    TweenService:Create(sub, t, {TextTransparency = 1}):Play()
-    TweenService:Create(bar,  t, {BackgroundTransparency = 1}):Play()
-    TweenService:Create(barBG, t, {BackgroundTransparency = 1}):Play()
-    TweenService:Create(logoImg, t, {ImageTransparency = 1}):Play()
-    TweenService:Create(paperBG, t, {ImageTransparency = 1}):Play()
-    wait(0.28)
+    bar.Size = UDim2.new(0,0,0.01,0)
+    if loadTime > 0 then
+        TweenService:Create(bar, TweenInfo.new(loadTime, Enum.EasingStyle.Quad), {Size = UDim2.new(0.6,0,0.01,0)}):Play()
+        task.wait(loadTime)
+    else
+        bar.Size = UDim2.new(0.6,0,0.01,0)
+    end
+
+    if fadeTime > 0 then
+        local t = TweenInfo.new(fadeTime, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+        TweenService:Create(sub, t, {TextTransparency = 1}):Play()
+        TweenService:Create(bar,  t, {BackgroundTransparency = 1}):Play()
+        TweenService:Create(barBG, t, {BackgroundTransparency = 1}):Play()
+        TweenService:Create(logoImg, t, {ImageTransparency = 1}):Play()
+        TweenService:Create(paperBG, t, {ImageTransparency = 1}):Play()
+        task.wait(fadeTime + 0.03)
+    end
 
     gui:Destroy()
 end

--- a/ReplicatedStorage/ClientModules/Abilities.lua
+++ b/ReplicatedStorage/ClientModules/Abilities.lua
@@ -3,10 +3,10 @@ local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
 
-local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
-local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+local CharacterManager = require(ReplicatedStorage.ClientModules.CharacterManager)
+local AbilityMetadata = require(ReplicatedStorage.ClientModules.AbilityMetadata)
 
-local Elements = ReplicatedStorage:WaitForChild("Elements")
+local Elements = ReplicatedStorage.Elements
 local DragonFX = nil
 local BeastFX = nil
 
@@ -32,7 +32,7 @@ local unlocked = {}
 Abilities.unlocked = unlocked
 
 local player = Players.LocalPlayer
-local abilitiesFolder = player:WaitForChild("Abilities", 5)
+local abilitiesFolder = player:FindFirstChild("Abilities")
 if abilitiesFolder then
         for _, child in ipairs(abilitiesFolder:GetChildren()) do
                 if child:IsA("BoolValue") and child.Value then
@@ -141,7 +141,7 @@ function Abilities.Rain()
         local offset = Vector3.new(0, 12, 0)
 	local caster = CharacterManager.character
 	local humanoidRoot = CharacterManager.humanoidRoot
-	local rainTemplate = ReplicatedStorage:WaitForChild("Elements"):WaitForChild("WaterElem"):FindFirstChild("WaterRain")
+    local rainTemplate = ReplicatedStorage.Elements.WaterElem:FindFirstChild("WaterRain")
 	if not rainTemplate then warn("?? Missing WaterRain template") return end
 
 	local target = nil -- insert your enemy targeting logic here

--- a/ReplicatedStorage/ClientModules/CharacterManager.lua
+++ b/ReplicatedStorage/ClientModules/CharacterManager.lua
@@ -12,34 +12,35 @@ CharacterManager.rightArm = nil
 CharacterManager.starModel = nil
 
 function CharacterManager.setup(player)
-	local function updateCharacterReferences()
-		CharacterManager.character = player.Character or player.CharacterAdded:Wait()
-		CharacterManager.humanoidRoot = CharacterManager.character:WaitForChild("HumanoidRootPart")
-		CharacterManager.humanoid = CharacterManager.character:WaitForChild("Humanoid")
-		CharacterManager.animator = CharacterManager.humanoid:WaitForChild("Animator")
-		CharacterManager.rightArm = CharacterManager.character:FindFirstChild("RightUpperArm") or CharacterManager.character:WaitForChild("RightUpperArm")
+    local function updateCharacterReferences()
+        CharacterManager.character = player.Character or player.CharacterAdded:Wait()
+        CharacterManager.humanoidRoot = CharacterManager.character.HumanoidRootPart
+        CharacterManager.humanoid = CharacterManager.character.Humanoid
+        CharacterManager.animator = CharacterManager.humanoid:FindFirstChild("Animator")
+        CharacterManager.rightArm = CharacterManager.character.RightUpperArm
 
-		local elements = ReplicatedStorage:WaitForChild("Elements")
-		local waterElem = elements:WaitForChild("WaterElem")
-		CharacterManager.starModel = waterElem:FindFirstChild("WaterStar")
+        local elements = ReplicatedStorage.Elements
+        local waterElem = elements and elements.WaterElem
+        CharacterManager.starModel = waterElem:FindFirstChild("WaterStar")
 
-		if not CharacterManager.starModel then
-			warn("?? WaterStar not found in WaterElem")
-		end
+        if not CharacterManager.starModel then
+            warn("?? WaterStar not found in WaterElem")
+        end
 
-		-- ? Init animations only after character + animator are ready
-		local success, CombatController = pcall(function()
-			return require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CombatController"))
-		end)
-		if success then
-			CombatController.initAnimations()
-		else
-			warn("?? Could not require CombatController for animation init")
-		end
-	end
+        -- ? Init animations only after character + animator are ready
+        local success, CombatController = pcall(function()
+            return require(ReplicatedStorage.ClientModules.CombatController)
+        end)
+        if success then
+            CombatController.initAnimations()
+        else
+            warn("?? Could not require CombatController for animation init")
+        end
+    end
 
-	updateCharacterReferences()
-	player.CharacterAdded:Connect(updateCharacterReferences)
+    updateCharacterReferences()
+    player.CharacterAdded:Connect(updateCharacterReferences)
 end
 
 return CharacterManager
+

--- a/ReplicatedStorage/ClientModules/CombatController.lua
+++ b/ReplicatedStorage/ClientModules/CombatController.lua
@@ -2,8 +2,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
-local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
-local Abilities = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("Abilities"))
+local CharacterManager = require(ReplicatedStorage.ClientModules.CharacterManager)
+local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
 
 local CombatController = {}
 

--- a/ReplicatedStorage/ClientModules/UI/ActionUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ActionUI.lua
@@ -4,12 +4,12 @@ local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
-local Abilities = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("Abilities"))
-local CombatController = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CombatController"))
+local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
+local CombatController = require(ReplicatedStorage.ClientModules.CombatController)
 
 local function ensureActions()
     local player = Players.LocalPlayer
-    local gui = player:WaitForChild("PlayerGui")
+    local gui = player.PlayerGui
 
     local screenGui = gui:FindFirstChild("ScreenGui")
     if not screenGui then

--- a/ReplicatedStorage/ClientModules/UI/ShopUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ShopUI.lua
@@ -1,12 +1,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
-local bootModules = ReplicatedStorage:WaitForChild("BootModules")
+local AbilityMetadata = require(ReplicatedStorage.ClientModules.AbilityMetadata)
+local bootModules = ReplicatedStorage.BootModules
 
 -- Try to load the ShopItems module but fall back to an empty table so the
 -- shop UI can still be created even if the module is missing. Returning nil
 -- from this module would cause requires to fail in BootUI.
 local ShopItems = {Elements = {}, Weapons = {}}
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
+local shopItemsModule = bootModules:FindFirstChild("ShopItems")
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else
@@ -77,7 +77,7 @@ function ShopUI.init(config, shop, bootUI, defaultTab)
 
     -- Abilities tab
     local abilitiesFrame = tabFrames["Abilities"]
-    local learnRF = ReplicatedStorage:WaitForChild("LearnAbility")
+    local learnRF = ReplicatedStorage:FindFirstChild("LearnAbility")
     for ability, info in pairs(AbilityMetadata) do
         local btn = Instance.new("TextButton")
         btn.Size = UDim2.new(1,0,0,40)
@@ -86,8 +86,10 @@ function ShopUI.init(config, shop, bootUI, defaultTab)
         btn.Text = ability .. " (" .. info.cost .. " Coins)"
         btn.Parent = abilitiesFrame
         btn.Activated:Connect(function()
-            if shop:Purchase(ability, info.cost) then
+            if shop:Purchase(ability, info.cost) and learnRF then
+                local start = os.clock()
                 learnRF:InvokeServer(ability)
+                warn(string.format("LearnAbility took %.3fs", os.clock() - start))
             end
         end)
     end

--- a/ServerScriptService/AbilityService.server.lua
+++ b/ServerScriptService/AbilityService.server.lua
@@ -1,5 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local AbilityMetadata = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("AbilityMetadata"))
+local AbilityMetadata = require(ReplicatedStorage.ClientModules.AbilityMetadata)
 local CurrencyService = shared.CurrencyService
 
 local learnRF = Instance.new("RemoteFunction")

--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -3,7 +3,7 @@ local RunService = game:GetService("RunService")
 local DataStoreService = game:GetService("DataStoreService")
 local HttpService = game:GetService("HttpService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local GameSettings = require(ReplicatedStorage:WaitForChild("GameSettings"))
+local GameSettings = require(ReplicatedStorage.GameSettings)
 
 -- single datastore for all player data
 local DataStore = DataStoreService:GetDataStore("PlayerData")

--- a/ServerScriptService/Init.server.lua
+++ b/ServerScriptService/Init.server.lua
@@ -127,15 +127,15 @@ local function ensureAnimateBits(char)
 end
 
 local function placeOnSpawn(char)
-	local hrp = char:FindFirstChild("HumanoidRootPart") or char:WaitForChild("HumanoidRootPart")
-	local hum = char:FindFirstChildOfClass("Humanoid")
-	local spawnPart = findSpawn()
-	if spawnPart then
-		local pos = spawnPart.CFrame.Position + Vector3.new(0,3,0)
-		local faceDir = getEndFacing()
-		hrp.CFrame = CFrame.lookAt(pos, pos + faceDir, Vector3.new(0,1,0))
-		if hum then hum:ChangeState(Enum.HumanoidStateType.GettingUp) end
-	end
+        local hrp = char:FindFirstChild("HumanoidRootPart")
+        local hum = char:FindFirstChildOfClass("Humanoid")
+        local spawnPart = findSpawn()
+        if hrp and spawnPart then
+                local pos = spawnPart.CFrame.Position + Vector3.new(0,3,0)
+                local faceDir = getEndFacing()
+                hrp.CFrame = CFrame.lookAt(pos, pos + faceDir, Vector3.new(0,1,0))
+                if hum then hum:ChangeState(Enum.HumanoidStateType.GettingUp) end
+        end
 end
 
 local function spawnNinjaModel(plr)

--- a/ServerScriptService/PersonaService.server.lua
+++ b/ServerScriptService/PersonaService.server.lua
@@ -8,7 +8,7 @@ local Players            = game:GetService("Players")
 local ReplicatedStorage  = game:GetService("ReplicatedStorage")
 local DataStoreService   = game:GetService("DataStoreService")
 local ServerStorage      = game:GetService("ServerStorage")
-local GameSettings       = require(ReplicatedStorage:WaitForChild("GameSettings"))
+local GameSettings       = require(ReplicatedStorage.GameSettings)
 
 -- === Remotes ===
 local rf = ReplicatedStorage:FindFirstChild("PersonaServiceRF")

--- a/ServerScriptService/RebirthService.lua
+++ b/ServerScriptService/RebirthService.lua
@@ -11,8 +11,8 @@ if not rebirthEvent then
     rebirthEvent.Parent = ReplicatedStorage
 end
 
-local dataScript = script.Parent:WaitForChild("DataSavingScript")
-local rebirthFunction = dataScript:WaitForChild("RebirthFunction")
+local dataScript = script.Parent.DataSavingScript
+local rebirthFunction = dataScript and dataScript.RebirthFunction
 
 rebirthEvent.OnServerEvent:Connect(function(player)
     rebirthFunction:Invoke(player)

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -8,12 +8,12 @@ if not shopEvent then
     shopEvent.Parent = ReplicatedStorage
 end
 
-local bootModules = ReplicatedStorage:WaitForChild("BootModules")
+local bootModules = ReplicatedStorage.BootModules
 
 -- Load ShopItems if available; otherwise continue with an empty list so the
 -- server script doesn't abort during startup.
 local ShopItems = {}
-local shopItemsModule = bootModules:WaitForChild("ShopItems", 5)
+local shopItemsModule = bootModules:FindFirstChild("ShopItems")
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -1,7 +1,7 @@
 -- Client bootstrap script loading BootModules
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Lighting = game:GetService("Lighting")
-local BootModules = ReplicatedStorage:WaitForChild("BootModules")
+local BootModules = ReplicatedStorage.BootModules
 
 -- Ensure a BlurEffect exists so other scripts can safely toggle it
 local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
@@ -12,11 +12,11 @@ if not blur then
     blur.Parent = Lighting
 end
 
-local PersonaUI = require(BootModules:WaitForChild("PersonaUI"))
-PersonaUI.start()
+local PersonaUI = require(BootModules.PersonaUI)
+PersonaUI.start({waitTime = 0})
 
-local DojoClient = require(BootModules:WaitForChild("DojoClient"))
+local DojoClient = require(BootModules.DojoClient)
 
-local BootUI = require(BootModules:WaitForChild("BootUI"))
+local BootUI = require(BootModules.BootUI)
 local config = BootUI.fetchData()
 BootUI.start(config)

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -6,18 +6,18 @@ local UserInputService = game:GetService("UserInputService")
 local CollectionService = game:GetService("CollectionService")
 local SoundService = game:GetService("SoundService")
 
-local Abilities = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("Abilities"))
+local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
 local AudioPlayer = require(ReplicatedStorage.ClientModules.AudioPlayer)
-local CharacterManager = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CharacterManager"))
-local CombatController = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("CombatController"))
-local bootModules = ReplicatedStorage:WaitForChild("BootModules")
+local CharacterManager = require(ReplicatedStorage.ClientModules.CharacterManager)
+local CombatController = require(ReplicatedStorage.ClientModules.CombatController)
+local bootModules = ReplicatedStorage.BootModules
 local merchModule = bootModules:FindFirstChild("MerchBooth")
 local MerchBooth = merchModule and require(merchModule)
-local GameSettings = require(ReplicatedStorage:WaitForChild("GameSettings"))
+local GameSettings = require(ReplicatedStorage.GameSettings)
 
 local player = Players.LocalPlayer
-local PlayerGui = player:WaitForChild("PlayerGui")
-local ActionUI = require(ReplicatedStorage:WaitForChild("ClientModules"):WaitForChild("UI"):WaitForChild("ActionUI"))
+local PlayerGui = player.PlayerGui
+local ActionUI = require(ReplicatedStorage.ClientModules.UI.ActionUI)
 
 -- Preload and validate audio assets
 -- Purge placeholder sounds before preloading
@@ -48,7 +48,7 @@ end
 --local ts = game:GetService("TweenService")
 --local currentCamera = game.Workspace.CurrentCamera
 
---local cameras = game.Workspace:WaitForChild("cameras")
+--local cameras = game.Workspace.Cameras
 
 --char.Hum
 --currentCamera.CameraType = Enum.CageType.Scriptable
@@ -58,8 +58,8 @@ end
 
 -- Attach WaterStar to character
 local function onCharacterAdded(character)
-	local elements = ReplicatedStorage:WaitForChild("Elements")
-	local waterElem = elements:WaitForChild("WaterElem")
+        local elements = ReplicatedStorage.Elements
+        local waterElem = elements and elements.WaterElem
 	local waterStarTemplate = waterElem:FindFirstChild("WaterStar")
 
 	if not waterStarTemplate then

--- a/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
@@ -1,6 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local bootModules = ReplicatedStorage:WaitForChild("BootModules")
-local MerchBooth = require(bootModules:WaitForChild("MerchBooth"))
+local bootModules = ReplicatedStorage.BootModules
+local MerchBooth = require(bootModules.MerchBooth)
 
 local items = {
     -- Asset IDs to display in the booth


### PR DESCRIPTION
## Summary
- eliminate WaitForChild dependencies for faster startup
- allow PersonaUI wait duration/fade to be customized and skip by default
- profile PersonaServiceRF and ability learning remote calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fddafcf48332a11d12f8c34cb3ba