### PR TITLE
Handle missing UI and merch modules

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -17,7 +17,15 @@ local GameSettings = require(ReplicatedStorage.GameSettings)
 
 local player = Players.LocalPlayer
 local PlayerGui = player.PlayerGui
-local ActionUI = require(ReplicatedStorage.ClientModules.UI.ActionUI)
+
+-- Attempt to load the ActionUI module but don't hard fail if it is missing.
+-- This mirrors the defensive loading used for other optional boot modules and
+-- prevents runtime errors when the file hasn't been replicated.
+local actionUIModule = ReplicatedStorage.ClientModules.UI:FindFirstChild("ActionUI")
+local ActionUI = actionUIModule and require(actionUIModule) or { init = function() end }
+if not actionUIModule then
+    warn("ActionUI module missing")
+end
 
 -- Preload and validate audio assets
 -- Purge placeholder sounds before preloading

--- a/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
@@ -1,6 +1,21 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local bootModules = ReplicatedStorage.BootModules
-local MerchBooth = require(bootModules.MerchBooth)
+
+-- BootModules may not be present in some testing environments. Guard against
+-- missing instances so the client's scripts continue running even if the
+-- merch booth functionality is unavailable.
+local bootModules = ReplicatedStorage:FindFirstChild("BootModules")
+if not bootModules then
+    warn("BootModules folder missing")
+    return
+end
+
+local merchModule = bootModules:FindFirstChild("MerchBooth")
+if not merchModule then
+    warn("MerchBooth module missing")
+    return
+end
+
+local MerchBooth = require(merchModule)
 
 local items = {
     -- Asset IDs to display in the booth


### PR DESCRIPTION
## Summary
- Guard ActionUI require to avoid runtime errors when module missing
- Safely load MerchBooth module only if BootModules and module exist

## Testing
- `luac -p StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua`
- `luac -p StarterPlayer/StarterPlayerScripts/MainLocalScript.lua` *(fails: ')' expected near ':')*


------
https://chatgpt.com/codex/tasks/task_e_68c5035989088332b9aca93740fdd0f3