### PR TITLE
Handle missing boot modules by waiting for replication

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/ShopUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ShopUI.lua
@@ -1,12 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage.ClientModules.AbilityMetadata)
-local bootModules = ReplicatedStorage.BootModules
+local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
 
 -- Try to load the ShopItems module but fall back to an empty table so the
 -- shop UI can still be created even if the module is missing. Returning nil
 -- from this module would cause requires to fail in BootUI.
 local ShopItems = {Elements = {}, Weapons = {}}
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules and (bootModules:FindFirstChild("ShopItems")
+    or bootModules:WaitForChild("ShopItems", 5))
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -8,12 +8,13 @@ if not shopEvent then
     shopEvent.Parent = ReplicatedStorage
 end
 
-local bootModules = ReplicatedStorage.BootModules
+local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
 
 -- Load ShopItems if available; otherwise continue with an empty list so the
 -- server script doesn't abort during startup.
 local ShopItems = {}
-local shopItemsModule = bootModules:FindFirstChild("ShopItems")
+local shopItemsModule = bootModules and (bootModules:FindFirstChild("ShopItems")
+    or bootModules:WaitForChild("ShopItems", 5))
 if shopItemsModule then
     ShopItems = require(shopItemsModule)
 else

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -6,14 +6,16 @@ local UserInputService = game:GetService("UserInputService")
 local CollectionService = game:GetService("CollectionService")
 local SoundService = game:GetService("SoundService")
 
-local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
-local AudioPlayer = require(ReplicatedStorage.ClientModules.AudioPlayer)
-local CharacterManager = require(ReplicatedStorage.ClientModules.CharacterManager)
-local CombatController = require(ReplicatedStorage.ClientModules.CombatController)
-local bootModules = ReplicatedStorage.BootModules
-local merchModule = bootModules:FindFirstChild("MerchBooth")
+local clientModules = ReplicatedStorage:WaitForChild("ClientModules", 5)
+local Abilities = require(clientModules:WaitForChild("Abilities"))
+local AudioPlayer = require(clientModules:WaitForChild("AudioPlayer"))
+local CharacterManager = require(clientModules:WaitForChild("CharacterManager"))
+local CombatController = require(clientModules:WaitForChild("CombatController"))
+local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
+local merchModule = bootModules and (bootModules:FindFirstChild("MerchBooth")
+    or bootModules:WaitForChild("MerchBooth", 5))
 local MerchBooth = merchModule and require(merchModule)
-local GameSettings = require(ReplicatedStorage.GameSettings)
+local GameSettings = require(ReplicatedStorage:WaitForChild("GameSettings", 5))
 
 local player = Players.LocalPlayer
 local PlayerGui = player.PlayerGui
@@ -21,7 +23,10 @@ local PlayerGui = player.PlayerGui
 -- Attempt to load the ActionUI module but don't hard fail if it is missing.
 -- This mirrors the defensive loading used for other optional boot modules and
 -- prevents runtime errors when the file hasn't been replicated.
-local actionUIModule = ReplicatedStorage.ClientModules.UI:FindFirstChild("ActionUI")
+local uiFolder = clientModules and (clientModules:FindFirstChild("UI")
+    or clientModules:WaitForChild("UI", 5))
+local actionUIModule = uiFolder and (uiFolder:FindFirstChild("ActionUI")
+    or uiFolder:WaitForChild("ActionUI", 5))
 local ActionUI = actionUIModule and require(actionUIModule) or { init = function() end }
 if not actionUIModule then
     warn("ActionUI module missing")

--- a/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua
@@ -3,13 +3,14 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 -- BootModules may not be present in some testing environments. Guard against
 -- missing instances so the client's scripts continue running even if the
 -- merch booth functionality is unavailable.
-local bootModules = ReplicatedStorage:FindFirstChild("BootModules")
+local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
 if not bootModules then
     warn("BootModules folder missing")
     return
 end
 
 local merchModule = bootModules:FindFirstChild("MerchBooth")
+    or bootModules:WaitForChild("MerchBooth", 5)
 if not merchModule then
     warn("MerchBooth module missing")
     return


### PR DESCRIPTION
## Summary
- Wait for BootModules and ShopItems before requiring to avoid missing module warnings
- Delay MerchBooth and ActionUI initialization until their modules replicate
- Ensure client modules exist before requiring them in MainLocalScript

## Testing
- `luac -p ServerScriptService/ShopScript.lua ReplicatedStorage/ClientModules/UI/ShopUI.lua StarterPlayer/StarterPlayerScripts/MerchBooth.client.lua StarterPlayer/StarterPlayerScripts/MainLocalScript.lua` *(fails: `')' expected near ':'` – Luau annotations unsupported by `luac`)*

------
https://chatgpt.com/codex/tasks/task_e_68c50921b6d48332b1e1d2e9b86e9ecb