### PR TITLE
Handle missing BootModules gracefully

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/ShopUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ShopUI.lua
@@ -1,6 +1,10 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AbilityMetadata = require(ReplicatedStorage.ClientModules.AbilityMetadata)
 local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
+if not bootModules then
+    warn("BootModules folder missing")
+    return {}
+end
 
 -- Try to load the ShopItems module but fall back to an empty table so the
 -- shop UI can still be created even if the module is missing. Returning nil

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -9,6 +9,10 @@ if not shopEvent then
 end
 
 local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
+if not bootModules then
+    warn("BootModules folder missing")
+    return
+end
 
 -- Load ShopItems if available; otherwise continue with an empty list so the
 -- server script doesn't abort during startup.

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -12,6 +12,10 @@ local AudioPlayer = require(clientModules:WaitForChild("AudioPlayer"))
 local CharacterManager = require(clientModules:WaitForChild("CharacterManager"))
 local CombatController = require(clientModules:WaitForChild("CombatController"))
 local bootModules = ReplicatedStorage:WaitForChild("BootModules", 5)
+if not bootModules then
+    warn("BootModules folder missing")
+    return
+end
 local merchModule = bootModules and (bootModules:FindFirstChild("MerchBooth")
     or bootModules:WaitForChild("MerchBooth", 5))
 local MerchBooth = merchModule and require(merchModule)


### PR DESCRIPTION
## Summary
- Guard server shop script against missing BootModules folder
- Bail from ShopUI and MainLocalScript when BootModules isn't present

## Testing
- `selene . 2>&1 | tail -n 20` *(fails: numerous parse errors and undefined globals)*

------
https://chatgpt.com/codex/tasks/task_e_68c515a4f2a083329b43589e0f0b2e37