### PR TITLE
Standardize slide action naming

### DIFF
--- a/ReplicatedStorage/ClientModules/CombatController.lua
+++ b/ReplicatedStorage/ClientModules/CombatController.lua
@@ -37,9 +37,9 @@ function CombatController.initAnimations()
 	local animations = {
 		Punch = "rbxassetid://16094588475",
 		Kick = "rbxassetid://16094054595",
-		Roll = "rbxassetid://16094647351",
-		Crch = "rbxassetid://16094669431",
-		Slid = "rbxassetid://16094829694"
+                Roll = "rbxassetid://16094647351",
+                Crch = "rbxassetid://16094669431",
+                Slide = "rbxassetid://16094829694"
 	}
 	task.spawn(function()
 		local tries = 0
@@ -116,7 +116,7 @@ function CombatController.perform(actionName)
 			warn("?? Animation track missing for:", actionName)
 		end
                 if snd then snd:Play() end
-                if actionName == "Slid" then
+                if actionName == "Slide" then
                        local humanoid = CharacterManager.humanoid
                        local originalSpeed = humanoid.WalkSpeed
                        humanoid.WalkSpeed = originalSpeed * slideSpeedMultiplier

--- a/ReplicatedStorage/ClientModules/UI/ActionUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ActionUI.lua
@@ -40,7 +40,7 @@ local BUTTON_DEFINITIONS = {
     -- Movement Actions (Yellow-green theme)
     {name = "RollButton", text = "ROLL", action = "Roll", category = "movement", keybind = "R"},
     {name = "CrouchButton", text = "CROUCH", action = "Crouch", category = "movement", keybind = "C"},
-    {name = "SlideButton", text = "SLIDE", action = "Slid", category = "movement", keybind = "Ctrl"},
+    {name = "SlideButton", text = "SLIDE", action = "Slide", category = "movement", keybind = "Ctrl"},
     
     -- Abilities (Blue theme)
     {name = "TossButton", text = "TOSS", action = "Toss", category = "ability", keybind = "F"},
@@ -249,7 +249,7 @@ function ActionUI.init()
         KickButton = "Kick",
         RollButton = "Roll",
         CrouchButton = "Crouch",
-        SlideButton = "Slid",
+        SlideButton = "Slide",
     }
 
     for buttonName, action in pairs(actionMap) do
@@ -292,7 +292,7 @@ function ActionUI.init()
         [Enum.KeyCode.Q] = "Kick",
         [Enum.KeyCode.R] = "Roll",
         [Enum.KeyCode.C] = "Crouch",
-        [Enum.KeyCode.LeftControl] = "Slid",
+        [Enum.KeyCode.LeftControl] = "Slide",
     }
 
     local ignoredInputKeys = {


### PR DESCRIPTION
## Summary
- unify slide action naming to "Slide" across combat controller and UI
- ensure slide button and keybind trigger correct animation and cooldown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5181735608332b0d8681e8ae5afed