### PR TITLE
Handle missing water element assets gracefully

### DIFF
--- a/ReplicatedStorage/ClientModules/Abilities.lua
+++ b/ReplicatedStorage/ClientModules/Abilities.lua
@@ -141,8 +141,19 @@ function Abilities.Rain()
         local offset = Vector3.new(0, 12, 0)
 	local caster = CharacterManager.character
 	local humanoidRoot = CharacterManager.humanoidRoot
-    local rainTemplate = ReplicatedStorage.Elements.WaterElem:FindFirstChild("WaterRain")
-	if not rainTemplate then warn("?? Missing WaterRain template") return end
+        local elements = ReplicatedStorage:FindFirstChild("Elements")
+        local waterElem = elements and elements:FindFirstChild("WaterElem")
+        local rainTemplate = waterElem and waterElem:FindFirstChild("WaterRain")
+        if not rainTemplate then
+                if not elements then
+                        warn("?? Elements folder missing: cannot load WaterRain template")
+                elseif not waterElem then
+                        warn("?? WaterElem folder missing: cannot load WaterRain template")
+                else
+                        warn("?? Missing WaterRain template")
+                end
+                return
+        end
 
 	local target = nil -- insert your enemy targeting logic here
 	for i = 1, math.random(3, 5) do

--- a/ReplicatedStorage/ClientModules/CharacterManager.lua
+++ b/ReplicatedStorage/ClientModules/CharacterManager.lua
@@ -19,12 +19,18 @@ function CharacterManager.setup(player)
         CharacterManager.animator = CharacterManager.humanoid:FindFirstChild("Animator")
         CharacterManager.rightArm = CharacterManager.character.RightUpperArm
 
-        local elements = ReplicatedStorage.Elements
-        local waterElem = elements and elements.WaterElem
-        CharacterManager.starModel = waterElem:FindFirstChild("WaterStar")
+        local elements = ReplicatedStorage:FindFirstChild("Elements")
+        local waterElem = elements and elements:FindFirstChild("WaterElem")
+        CharacterManager.starModel = waterElem and waterElem:FindFirstChild("WaterStar") or nil
 
         if not CharacterManager.starModel then
-            warn("?? WaterStar not found in WaterElem")
+            if not elements then
+                warn("?? Elements folder missing: cannot locate WaterStar")
+            elseif not waterElem then
+                warn("?? WaterElem folder missing: cannot locate WaterStar")
+            else
+                warn("?? WaterStar not found in WaterElem")
+            end
         end
 
         -- ? Init animations only after character + animator are ready

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -98,18 +98,28 @@ end
 
 -- Attach WaterStar to character
 local function onCharacterAdded(character)
-        local elements = ReplicatedStorage.Elements
-        local waterElem = elements and elements.WaterElem
-	local waterStarTemplate = waterElem:FindFirstChild("WaterStar")
+        local elements = ReplicatedStorage:FindFirstChild("Elements")
+        if not elements then
+                warn("WaterStar template not found: Elements folder missing")
+                return
+        end
 
-	if not waterStarTemplate then
-		warn("WaterStar template not found in WaterElem!")
-		return
-	end
+        local waterElem = elements:FindFirstChild("WaterElem")
+        if not waterElem then
+                warn("WaterStar template not found: WaterElem folder missing")
+                return
+        end
 
-	local waterStarClone = waterStarTemplate:Clone()
-	waterStarClone.Name = "WaterStarClone"
-	waterStarClone.Parent = character
+        local waterStarTemplate = waterElem:FindFirstChild("WaterStar")
+
+        if not waterStarTemplate then
+                warn("WaterStar template not found in WaterElem!")
+                return
+        end
+
+        local waterStarClone = waterStarTemplate:Clone()
+        waterStarClone.Name = "WaterStarClone"
+        waterStarClone.Parent = character
 end
 
 if player.Character then


### PR DESCRIPTION
## Summary
- guard client scripts against missing `Elements/WaterElem` assets so bootstrap logic keeps running
- surface clearer warnings when the Elements or WaterElem folders are absent before trying to clone effects

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca2d80215c8332abe8c236641639a4