### PR TITLE
Ensure action UI initializes when the client loads

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -1225,7 +1225,15 @@ end
 
 -- New: Function to start cooldown from external scripts
 function ActionUI.startCooldown(buttonName, duration)
-	startCooldown(buttonName, duration)
+        startCooldown(buttonName, duration)
 end
+
+task.spawn(function()
+        if not game:IsLoaded() then
+                game.Loaded:Wait()
+        end
+
+        ActionUI.init()
+end)
 
 return ActionUI


### PR DESCRIPTION
## Summary
- start the action UI once the client has loaded to restore the combat and ability buttons

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca63dec1c08332948b3087ac222ea7