### PR TITLE
Fix combat input by initializing character manager

### DIFF
--- a/ReplicatedStorage/ClientModules/CharacterManager.lua
+++ b/ReplicatedStorage/ClientModules/CharacterManager.lua
@@ -1,6 +1,7 @@
 -- CharacterManager Module
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
 
 local CharacterManager = {}
 
@@ -10,43 +11,141 @@ CharacterManager.humanoidRoot = nil
 CharacterManager.animator = nil
 CharacterManager.rightArm = nil
 CharacterManager.starModel = nil
+CharacterManager.isCrouching = false
 
-function CharacterManager.setup(player)
-    local function updateCharacterReferences()
-        CharacterManager.character = player.Character or player.CharacterAdded:Wait()
-        CharacterManager.humanoidRoot = CharacterManager.character.HumanoidRootPart
-        CharacterManager.humanoid = CharacterManager.character.Humanoid
-        CharacterManager.animator = CharacterManager.humanoid:FindFirstChild("Animator")
-        CharacterManager.rightArm = CharacterManager.character.RightUpperArm
+CharacterManager._player = nil
+CharacterManager._characterAddedConnection = nil
 
+local function safeWaitForChild(parent, childName, timeout)
+        if not parent then
+                return nil
+        end
+
+        local child = parent:FindFirstChild(childName)
+        if child then
+                return child
+        end
+
+        local ok, result = pcall(function()
+                return parent:WaitForChild(childName, timeout or 5)
+        end)
+
+        if ok then
+                return result
+        end
+
+        return nil
+end
+
+local function updateStarModel()
         local elements = ReplicatedStorage:FindFirstChild("Elements")
         local waterElem = elements and elements:FindFirstChild("WaterElem")
         CharacterManager.starModel = waterElem and waterElem:FindFirstChild("WaterStar") or nil
 
         if not CharacterManager.starModel then
-            if not elements then
-                warn("?? Elements folder missing: cannot locate WaterStar")
-            elseif not waterElem then
-                warn("?? WaterElem folder missing: cannot locate WaterStar")
-            else
-                warn("?? WaterStar not found in WaterElem")
-            end
+                if not elements then
+                        warn("?? Elements folder missing: cannot locate WaterStar")
+                elseif not waterElem then
+                        warn("?? WaterElem folder missing: cannot locate WaterStar")
+                else
+                        warn("?? WaterStar not found in WaterElem")
+                end
+        end
+end
+
+function CharacterManager.setup(player)
+        if not player then
+                warn("?? CharacterManager.setup called without player")
+                return
         end
 
-        -- ? Init animations only after character + animator are ready
-        local success, CombatController = pcall(function()
-            return require(ReplicatedStorage.ClientModules.CombatController)
-        end)
-        if success then
-            CombatController.initAnimations()
+        if CharacterManager._player == player and CharacterManager._characterAddedConnection then
+                return
+        end
+
+        CharacterManager._player = player
+
+        if CharacterManager._characterAddedConnection then
+                CharacterManager._characterAddedConnection:Disconnect()
+                CharacterManager._characterAddedConnection = nil
+        end
+
+        local function updateCharacterReferences(character)
+                if character then
+                        CharacterManager.character = character
+                else
+                        local resolved = player.Character
+                        if not resolved then
+                                local ok, newCharacter = pcall(function()
+                                        return player.CharacterAdded:Wait()
+                                end)
+                                if ok then
+                                        resolved = newCharacter
+                                end
+                        end
+
+                        if not resolved then
+                                warn("?? CharacterManager failed to resolve character for player " .. player.Name)
+                                return
+                        end
+
+                        CharacterManager.character = resolved
+                        character = resolved
+                end
+
+                CharacterManager.humanoidRoot = safeWaitForChild(character, "HumanoidRootPart")
+
+                CharacterManager.humanoid = safeWaitForChild(character, "Humanoid")
+                if not CharacterManager.humanoid then
+                        warn("?? CharacterManager could not locate Humanoid for player " .. player.Name)
+                        CharacterManager.animator = nil
+                else
+                        CharacterManager.animator = safeWaitForChild(CharacterManager.humanoid, "Animator")
+                        if not CharacterManager.animator then
+                                warn("?? CharacterManager could not locate Animator on humanoid for player " .. player.Name)
+                        end
+                end
+
+                CharacterManager.rightArm = safeWaitForChild(character, "RightUpperArm")
+                        or safeWaitForChild(character, "Right Arm")
+                        or safeWaitForChild(character, "RightHand")
+                if not CharacterManager.rightArm then
+                        warn("?? CharacterManager could not locate a right arm reference for player " .. player.Name)
+                end
+
+                CharacterManager.isCrouching = false
+
+                updateStarModel()
+
+                local success, CombatController = pcall(function()
+                        return require(ReplicatedStorage.ClientModules.CombatController)
+                end)
+                if success and CombatController then
+                        CombatController.initAnimations()
+                else
+                        warn("?? Could not require CombatController for animation init")
+                end
+        end
+
+        CharacterManager._characterAddedConnection = player.CharacterAdded:Connect(updateCharacterReferences)
+
+        local currentCharacter = player.Character
+        if currentCharacter then
+                updateCharacterReferences(currentCharacter)
         else
-            warn("?? Could not require CombatController for animation init")
+                task.spawn(updateCharacterReferences)
         end
-    end
+end
 
-    updateCharacterReferences()
-    player.CharacterAdded:Connect(updateCharacterReferences)
+if RunService:IsClient() then
+        task.defer(function()
+                local player = Players.LocalPlayer
+                while not player do
+                        task.wait()
+                        player = Players.LocalPlayer
+                end
+                CharacterManager.setup(player)
+        end)
 end
 
 return CharacterManager
-

--- a/ReplicatedStorage/ClientModules/CombatController.lua
+++ b/ReplicatedStorage/ClientModules/CombatController.lua
@@ -1,6 +1,7 @@
 -- CombatController Module
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
+local Players = game:GetService("Players")
 
 local CharacterManager = require(ReplicatedStorage.ClientModules.CharacterManager)
 local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
@@ -34,31 +35,31 @@ if snd then
 end
 
 function CombatController.initAnimations()
-	local animations = {
-		Punch = "rbxassetid://16094588475",
-		Kick = "rbxassetid://16094054595",
+        local animations = {
+                Punch = "rbxassetid://16094588475",
+                Kick = "rbxassetid://16094054595",
                 Roll = "rbxassetid://16094647351",
                 Crch = "rbxassetid://16094669431",
                 Slide = "rbxassetid://16094829694"
-	}
-	task.spawn(function()
-		local tries = 0
-		while not CharacterManager.animator and tries < 10 do
-			task.wait(0.2)
-			tries += 1
-		end
-		local animator = CharacterManager.animator
-		if not animator then
-			warn("?? Animator still not available after waiting. Aborting animation init.")
-			return
-		end
-		for name, id in pairs(animations) do
-			local anim = Instance.new("Animation")
-			anim.Name = name .. "Anim"
-			anim.AnimationId = id
-			animationTracks[name] = animator:LoadAnimation(anim)
-		end
-	end)
+        }
+        task.spawn(function()
+                local tries = 0
+                while not CharacterManager.animator and tries < 10 do
+                        task.wait(0.2)
+                        tries += 1
+                end
+                local animator = CharacterManager.animator
+                if not animator then
+                        warn("?? Animator still not available after waiting. Aborting animation init.")
+                        return
+                end
+                for name, id in pairs(animations) do
+                        local anim = Instance.new("Animation")
+                        anim.Name = name .. "Anim"
+                        anim.AnimationId = id
+                        animationTracks[name] = animator:LoadAnimation(anim)
+                end
+        end)
 end
 
 function CombatController.getTracks()
@@ -75,6 +76,14 @@ end
 
 function CombatController.perform(actionName)
         print("Performing action:", actionName)
+
+        if not CharacterManager.humanoid then
+                local player = Players.LocalPlayer
+                if player then
+                        CharacterManager.setup(player)
+                end
+        end
+
         local abilityFunc = Abilities[actionName]
         if type(abilityFunc) == "function" then
                 if Abilities.isUnlocked(actionName) then
@@ -84,40 +93,48 @@ function CombatController.perform(actionName)
                 end
                 return
         end
+
         if actionName == "Crouch" then
+                local humanoid = CharacterManager.humanoid
+                if not humanoid then
+                        warn("?? Cannot toggle crouch without humanoid reference")
+                        return
+                end
+
                 local track = animationTracks["Crch"]
-		if track then
-			if CharacterManager.isCrouching then
-				track:AdjustSpeed(1)
-				track:Play()
-				CharacterManager.humanoid.WalkSpeed = 24
-				task.delay(0.23, function()
-					track:Stop()
-				end)
-				CharacterManager.isCrouching = false
-			else
-				track.TimePosition = 0.1
-				track:Play()
-				track:AdjustSpeed(0)
-				CharacterManager.humanoid.WalkSpeed = 8
-				CharacterManager.isCrouching = true
-			end
-		end
-		return
-	end
-	if canStrike and CharacterManager.humanoid and CharacterManager.humanoid.Health > 0 then
-		canStrike = false
-		local track = animationTracks[actionName]
-		print("ActionName:", actionName, "Track:", track)
-		if track then
-			print("?? Playing animation for:", actionName)
-			track:Play()
-		else
-			warn("?? Animation track missing for:", actionName)
-		end
+                if track then
+                        if CharacterManager.isCrouching then
+                                track:AdjustSpeed(1)
+                                track:Play()
+                                humanoid.WalkSpeed = 24
+                                task.delay(0.23, function()
+                                        track:Stop()
+                                end)
+                                CharacterManager.isCrouching = false
+                        else
+                                track.TimePosition = 0.1
+                                track:Play()
+                                track:AdjustSpeed(0)
+                                humanoid.WalkSpeed = 8
+                                CharacterManager.isCrouching = true
+                        end
+                end
+                return
+        end
+
+        local humanoid = CharacterManager.humanoid
+        if canStrike and humanoid and humanoid.Health > 0 then
+                canStrike = false
+                local track = animationTracks[actionName]
+                print("ActionName:", actionName, "Track:", track)
+                if track then
+                        print("?? Playing animation for:", actionName)
+                        track:Play()
+                else
+                        warn("?? Animation track missing for:", actionName)
+                end
                 if snd then snd:Play() end
                 if actionName == "Slide" then
-                       local humanoid = CharacterManager.humanoid
                        local originalSpeed = humanoid.WalkSpeed
                        humanoid.WalkSpeed = originalSpeed * slideSpeedMultiplier
                        task.delay(slideDuration, function()


### PR DESCRIPTION
## Summary
- automatically set up the character manager for the local player, ensure humanoid references are refreshed, and preload animations once they exist
- request character manager setup from the combat controller when needed and guard crouch logic when no humanoid is available

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb6a49d4e48332b0e85242fba2542d