### PR TITLE
Refactor HUD creation into reusable module

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -6,8 +6,6 @@ local BootUI = {}
 local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local TweenService      = game:GetService("TweenService")
-local ContentProvider   = game:GetService("ContentProvider")
-local GuiService        = game:GetService("GuiService")
 local TeleportService   = game:GetService("TeleportService")
 local RunService        = game:GetService("RunService")
 local Workspace         = game:GetService("Workspace")
@@ -18,8 +16,6 @@ local player  = Players.LocalPlayer
 local rf      = ReplicatedStorage.PersonaServiceRF
 local cam     = Workspace.CurrentCamera
 local enterRE = ReplicatedStorage:FindFirstChild("EnterDojoRE") -- created by server script
-
-local topInsetY = GuiService:GetGuiInset().Y
 
 local function profileRF(action, data)
     local start = os.clock()
@@ -48,9 +44,7 @@ end
 local Cosmetics       = require(ReplicatedStorage.BootModules.Cosmetics)
 local CurrencyService = require(ReplicatedStorage.BootModules.CurrencyService)
 local Shop            = require(ReplicatedStorage.BootModules.Shop)
-local ShopUI          = require(ReplicatedStorage.ClientModules.UI.ShopUI)
-local QuestUI         = require(ReplicatedStorage.ClientModules.UI.QuestUI)
-local BackpackUI      = require(ReplicatedStorage.ClientModules.UI.BackpackUI)
+local WorldHUD        = require(ReplicatedStorage.ClientModules.UI.WorldHUD)
 local TeleportClient  = require(ReplicatedStorage.ClientModules.TeleportClient)
 local DojoClient      = require(ReplicatedStorage.BootModules.DojoClient)
 
@@ -58,8 +52,86 @@ function BootUI.unlockRealm(name)
     TeleportClient.unlockRealm(name)
 end
 
+function BootUI.getHUD()
+    return BootUI.hud
+end
+
+function BootUI.showLoadout()
+    local hud = BootUI.hud
+    if hud and hud.showLoadout then
+        hud:showLoadout()
+    elseif BootUI.loadout then
+        BootUI.loadout.Visible = true
+    end
+end
+
+function BootUI.hideLoadout()
+    local hud = BootUI.hud
+    if hud and hud.hideLoadout then
+        hud:hideLoadout()
+    elseif BootUI.loadout then
+        BootUI.loadout.Visible = false
+    end
+end
+
+function BootUI.setShopButtonVisible(visible)
+    local hud = BootUI.hud
+    if hud and hud.setShopButtonVisible then
+        hud:setShopButtonVisible(visible)
+    elseif BootUI.shopBtn then
+        BootUI.shopBtn.Visible = visible and true or false
+    end
+end
+
+function BootUI.toggleShop(defaultTab)
+    local hud = BootUI.hud
+    if hud and hud.toggleShop then
+        local visible = hud:toggleShop(defaultTab)
+        BootUI.shopFrame = hud.shopFrame
+        return visible
+    end
+end
+
+function BootUI.populateBackpackUI(data)
+    local hud = BootUI.hud
+    if hud and hud.setBackpackData then
+        hud:setBackpackData(data)
+    end
+end
+
+function BootUI.getSelectedRealm()
+    local hud = BootUI.hud
+    if hud and hud.getSelectedRealm then
+        return hud:getSelectedRealm()
+    end
+end
+
+function BootUI.getRealmDisplayName(realmKey)
+    local hud = BootUI.hud
+    if hud and hud.getRealmDisplayName then
+        return hud:getRealmDisplayName(realmKey)
+    end
+end
+
+function BootUI.destroyHUD()
+    local hud = BootUI.hud
+    if hud and hud.destroy then
+        hud:destroy()
+    end
+    BootUI.hud = nil
+end
+
+function BootUI.hideOverlay()
+    if BootUI.introGui then
+        BootUI.introGui.Enabled = false
+    end
+end
+
+function BootUI.destroy()
+    BootUI.hideOverlay()
+end
+
 local currencyService
-local backpackUI
 
 function BootUI.start(config)
     config = config or {}
@@ -78,10 +150,21 @@ local shop            = Shop.new(config, currencyService)
 BootUI.currencyService = currencyService
 BootUI.shop = shop
 
-    -- connect currency updates after service is created but before backpack UI is defined
+local hud = WorldHUD.new(config, {currencyService = currencyService, shop = shop})
+BootUI.hud = hud
+BootUI.loadout = hud and hud:getLoadoutFrame() or nil
+BootUI.shopBtn = hud and hud:getShopButton() or nil
+BootUI.shopFrame = hud and hud.shopFrame or nil
+
+local questInterface = hud and hud:getQuestInterface() or nil
+BootUI.questInterface = questInterface
+BootUI.buildCharacterPreview = questInterface and questInterface.buildCharacterPreview or nil
+
+    -- connect currency updates after service is created so backpack UI stays in sync
     currencyService.BalanceChanged.Event:Connect(function(coins, orbs, elements)
-        if backpackUI then
-            backpackUI:updateCurrency(coins, orbs, elements)
+        local currentHud = BootUI.hud
+        if currentHud then
+            currentHud:updateCurrency(coins, orbs, elements)
         end
     end)
 
@@ -212,6 +295,7 @@ ui.Name           = "IntroGui"
 ui.IgnoreGuiInset = true
 ui.DisplayOrder   = 100
 ui.Parent         = player.PlayerGui
+BootUI.introGui   = ui
 
 local root = Instance.new("Frame")
 root.Size = UDim2.fromScale(1,1)
@@ -220,83 +304,6 @@ root.Parent = ui
 
 BootUI.root = root
 Cosmetics.init(config, root, BootUI)
-local function toggleShop(defaultTab)
-    if not BootUI.shopFrame then
-        BootUI.shopFrame = ShopUI.init(config, shop, BootUI, defaultTab)
-    else
-        BootUI.shopFrame.Visible = not BootUI.shopFrame.Visible
-    end
-    if BootUI.shopFrame and BootUI.shopFrame.Visible and defaultTab then
-        if ShopUI.setTab then
-            ShopUI.setTab(defaultTab)
-        end
-    end
-end
-BootUI.toggleShop = toggleShop
-if config.showShop then
-    toggleShop()
-end
-local shopBtn = Instance.new("TextButton")
-shopBtn.Size = UDim2.fromScale(0.1,0.06)
-shopBtn.AnchorPoint = Vector2.new(1,1)
-shopBtn.Position = UDim2.fromScale(0.98,0.98)
-shopBtn.Text = "Shop"
-shopBtn.Font = Enum.Font.GothamSemibold
-shopBtn.TextScaled = true
-shopBtn.TextColor3 = Color3.new(1,1,1)
-shopBtn.BackgroundColor3 = Color3.fromRGB(50,120,255)
-shopBtn.AutoButtonColor = true
-shopBtn.ZIndex = 10
-shopBtn.Parent = root
-shopBtn.Visible = false
-BootUI.shopBtn = shopBtn
-shopBtn.Activated:Connect(function()
-    toggleShop()
-end)
-
-    -- teleport UI placeholders
-    local teleFrame = Instance.new("Frame")
-    teleFrame.Name = "TeleFrame"
-    teleFrame.Size = UDim2.fromScale(1,1)
-    teleFrame.BackgroundTransparency = 1
-    teleFrame.Visible = false
-    teleFrame.Parent = root
-
-    local zoneButtons = {"Atom","Fire","Grow","Ice","Light","Metal","Water","Wind","Dojo","Starter"}
-    for _, zone in ipairs(zoneButtons) do
-        local button = Instance.new("TextButton")
-        button.Name = zone .. "Button"
-        button.Size = UDim2.new(0,0,0,0)
-        button.Visible = false
-        button.Text = zone
-        button.Parent = teleFrame
-    end
-
-    local worldFrame = Instance.new("Frame")
-    worldFrame.Name = "WorldTeleFrame"
-    worldFrame.Size = UDim2.fromScale(1,1)
-    worldFrame.BackgroundTransparency = 1
-    worldFrame.Visible = false
-    worldFrame.Parent = root
-
-    local enterRealmButton = Instance.new("TextButton")
-    enterRealmButton.Name = "EnterRealmButton"
-    enterRealmButton.Size = UDim2.new(0,0,0,0)
-    enterRealmButton.Visible = false
-    enterRealmButton.Text = "Enter"
-    enterRealmButton.Parent = worldFrame
-
-    for realmName, _ in pairs(TeleportClient.worldSpawnIds) do
-        local button = Instance.new("TextButton")
-        button.Name = realmName .. "Button"
-        button.Size = UDim2.new(0,0,0,0)
-        button.Visible = false
-        button.Text = realmName
-        button.Parent = worldFrame
-    end
-
-    TeleportClient.bindZoneButtons(root)
-    TeleportClient.bindWorldButtons(root)
 
 -- Intro visuals
 local fade = Instance.new("Frame")
@@ -306,309 +313,63 @@ fade.BackgroundTransparency = 1
 fade.ZIndex = 50
 fade.Parent = root
 
--- =====================
--- Loadout (viewport + backpack + emotes)
--- =====================
-local loadout = Instance.new("Frame")
-loadout.Size = UDim2.fromScale(1,1)
-loadout.BackgroundTransparency = 1
-loadout.Visible = false
-loadout.ZIndex = 20
-loadout.Parent = root
-BootUI.loadout = loadout
-
-local baseY = topInsetY + 20
-
-local loadTitle = Instance.new("TextLabel")
-loadTitle.Size = UDim2.new(1,-40,0,60)
-loadTitle.Position = UDim2.new(0.5,0,0,baseY)
-loadTitle.AnchorPoint = Vector2.new(0.5,0)
-loadTitle.BackgroundTransparency = 0.6
-loadTitle.TextXAlignment = Enum.TextXAlignment.Center
-loadTitle.Text = "Loadout"
-loadTitle.Font = Enum.Font.GothamBold
-loadTitle.TextScaled = true
-loadTitle.TextColor3 = Color3.fromRGB(255,200,120)
-loadTitle.Parent = loadout
-
-local quest = QuestUI.init(loadout, baseY)
-BootUI.buildCharacterPreview = quest.buildCharacterPreview
-backpackUI = BackpackUI.init(loadout, baseY)
-
-local btnRow = Instance.new("Frame")
-btnRow.Size = UDim2.new(1,-40,0,60)
-btnRow.Position = UDim2.new(0,20,1,-80)
-btnRow.BackgroundTransparency = 1
-btnRow.Parent = loadout
-
-local function makeAction(text, rightAlign)
-    local b = Instance.new("TextButton")
-    b.Size = UDim2.new(0,240,1,0)
-    b.Position = rightAlign and UDim2.new(1,-250,0,0) or UDim2.fromOffset(0,0)
-    b.AnchorPoint = rightAlign and Vector2.new(1,0) or Vector2.new(0,0)
-    b.Text = text
-    b.Font = Enum.Font.GothamSemibold
-    b.TextScaled = true
-    b.TextColor3 = Color3.new(1,1,1)
-    b.BackgroundColor3 = Color3.fromRGB(50,120,255)
-    b.AutoButtonColor = true
-    b.Parent = btnRow
-    return b
-end
-
-local btnBack       = makeAction("Back", false)
-local btnEnterRealm = makeAction("Enter Realm", true)
-
--- scrolling list of realm buttons between Back and Enter
-local realmScroll = Instance.new("ScrollingFrame")
-realmScroll.Size = UDim2.new(1,-500,1,0)
-realmScroll.Position = UDim2.fromOffset(250,-100)
-realmScroll.BackgroundTransparency = 1
-realmScroll.ScrollBarThickness = 6
-realmScroll.CanvasSize = UDim2.new()
-realmScroll.Parent = btnRow
-local realmLayout = Instance.new("UIListLayout", realmScroll)
-realmLayout.FillDirection = Enum.FillDirection.Horizontal
-realmLayout.Padding = UDim.new(0,6)
-realmLayout:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
-    realmScroll.CanvasSize = UDim2.new(0, realmLayout.AbsoluteContentSize.X, 0, 0)
-end)
-
-local realmButtons = {}
-local selectedRealm = nil
-local realmInfo = {
-    {key = "StarterDojo",   name = "Starter Dojo"},
-    {key = "SecretVillage", name = "Secret Village of Elementara"},
-    {key = "Water",         name = "Water"},
-    {key = "Fire",          name = "Fire"},
-    {key = "Wind",          name = "Wind"},
-    {key = "Growth",        name = "Growth"},
-    {key = "Ice",           name = "Ice"},
-    {key = "Light",         name = "Light"},
-    {key = "Metal",         name = "Metal"},
-    {key = "Strength",      name = "Strength"},
-    {key = "Atoms",         name = "Atoms"},
-}
-
-local realmDisplayLookup = {}
-for _,info in ipairs(realmInfo) do realmDisplayLookup[info.key] = info.name end
-
-local realmsFolder = player:FindFirstChild("Realms")
-
-local function updateRealmButton(key)
-    local btn = realmButtons[key]
-    if not btn then return end
-    local unlocked = false
-    if realmsFolder then
-        local flag = realmsFolder:FindFirstChild(key)
-        unlocked = flag and flag.Value
-    end
-    btn.Active = unlocked
-    btn.AutoButtonColor = unlocked
-    btn.BackgroundColor3 = unlocked and Color3.fromRGB(50,120,255) or Color3.fromRGB(80,80,80)
-    btn.TextColor3 = unlocked and Color3.new(1,1,1) or Color3.fromRGB(170,170,170)
-end
-
-local function setSelected(key)
-    selectedRealm = key
-    for k, b in pairs(realmButtons) do
-        if k == key then
-            b.BackgroundColor3 = Color3.fromRGB(80,160,255)
-        else
-            updateRealmButton(k)
-        end
-    end
-    local hasPlace = (key == "StarterDojo") or (TeleportClient.WorldPlaceIds[key] and TeleportClient.WorldPlaceIds[key] > 0)
-    btnEnterRealm.Active = hasPlace
-    btnEnterRealm.AutoButtonColor = hasPlace
-    btnEnterRealm.BackgroundColor3 = hasPlace and Color3.fromRGB(50,120,255) or Color3.fromRGB(80,80,80)
-    btnEnterRealm.Text = "Enter " .. (realmDisplayLookup[key] or "Realm")
-end
-
-for _, info in ipairs(realmInfo) do
-    local btn = Instance.new("TextButton")
-    btn.Size = UDim2.new(0,160,1,0)
-    btn.Text = info.name
-    btn.Font = Enum.Font.Gotham
-    btn.TextScaled = true
-    btn.BackgroundColor3 = Color3.fromRGB(80,80,80)
-    btn.TextColor3 = Color3.fromRGB(170,170,170)
-    btn.AutoButtonColor = false
-    btn.Parent = realmScroll
-    realmButtons[info.key] = btn
-    btn.Activated:Connect(function()
-        if not btn.Active then return end
-        setSelected(info.key)
-    end)
-    if realmsFolder then
-        local flag = realmsFolder:FindFirstChild(info.key)
-        if flag then
-            flag:GetPropertyChangedSignal("Value"):Connect(function()
-                updateRealmButton(info.key)
-            end)
-        end
-    end
-    updateRealmButton(info.key)
-end
-
-btnEnterRealm.Active = false
-btnEnterRealm.AutoButtonColor = false
-
-if realmsFolder then
-    realmsFolder.ChildAdded:Connect(function(child)
-        local btn = realmButtons[child.Name]
-        if btn then
-            child:GetPropertyChangedSignal("Value"):Connect(function()
-                updateRealmButton(child.Name)
-            end)
-            updateRealmButton(child.Name)
-        end
+local backButton = hud and hud.backButton
+if backButton then
+    backButton.MouseButton1Click:Connect(function()
+        applyStartCam()
+        Cosmetics.showDojoPicker()
     end)
 end
 
--- =====================
--- Helpers (UI logic)
--- =====================
-local function clearChildren(p)
-    for _, c in ipairs(p:GetChildren()) do
-        if not c:IsA("UIListLayout") then
-            c:Destroy()
-        end
-    end
-end
+local enterRealmButton = hud and hud.enterRealmButton
+if enterRealmButton then
+    enterRealmButton.MouseButton1Click:Connect(function()
+        local realmName = BootUI.getSelectedRealm()
+        if not realmName then return end
+        local displayName = BootUI.getRealmDisplayName(realmName) or realmName
+        DojoClient.start(displayName)
+        if realmName == "StarterDojo" then
+            TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
+            task.wait(0.28)
 
-local function addHeader(text)
-    local h = Instance.new("TextLabel")
-    h.Size = UDim2.new(1,0,0,30)
-    h.BackgroundTransparency = 1
-    h.TextXAlignment = Enum.TextXAlignment.Left
-    h.Font = Enum.Font.GothamSemibold
-    h.TextScaled = true
-    h.TextColor3 = Color3.fromRGB(200,200,200)
-    h.Text = text
-    h.Parent = list
-end
+            local personaType, chosenSlot = Cosmetics.getSelectedPersona()
+            if enterRE then
+                enterRE:FireServer({ type = personaType, slot = chosenSlot })
+            else
+                warn("EnterDojoRE missing on server")
+            end
 
-local function addSimpleRow(label, value)
-    local row = Instance.new("Frame")
-    row.Size = UDim2.new(1,0,0,30)
-    row.BackgroundTransparency = 1
-    row.Parent = list
+            task.wait(0.2)
+            local char = player.Character or player.CharacterAdded:Wait()
+            local hum = char:FindFirstChildOfClass("Humanoid")
+            cam.CameraType = Enum.CameraType.Custom
+            if hum then cam.CameraSubject = hum end
 
-    local name = Instance.new("TextLabel")
-    name.Size = UDim2.new(0.6,-10,1,0)
-    name.Position = UDim2.fromOffset(10,0)
-    name.BackgroundTransparency = 1
-    name.TextXAlignment = Enum.TextXAlignment.Left
-    name.Font = Enum.Font.Gotham
-    name.TextScaled = true
-    name.TextColor3 = Color3.new(1,1,1)
-    name.Text = label
-    name.Parent = row
-
-    local val = Instance.new("TextLabel")
-    val.Size = UDim2.new(0.4,-10,1,0)
-    val.Position = UDim2.new(0.6,0,0,0)
-    val.BackgroundTransparency = 1
-    val.TextXAlignment = Enum.TextXAlignment.Right
-    val.Font = Enum.Font.Gotham
-    val.TextScaled = true
-    val.TextColor3 = Color3.fromRGB(230,230,230)
-    val.Text = tostring(value or 0)
-    val.Parent = row
-end
-
-local function addItemRow(it)
-    local row = Instance.new("Frame")
-    row.Size = UDim2.new(1,0,0,40)
-    row.BackgroundColor3 = Color3.fromRGB(32,34,36)
-    row.BorderSizePixel = 0
-    row.Parent = list
-
-    local name = Instance.new("TextLabel")
-    name.Size = UDim2.new(0.6,-10,1,0)
-    name.Position = UDim2.fromOffset(10,0)
-    name.BackgroundTransparency = 1
-    name.TextXAlignment = Enum.TextXAlignment.Left
-    name.Font = Enum.Font.Gotham
-    name.TextScaled = true
-    name.TextColor3 = Color3.new(1,1,1)
-    name.Text = it.name
-    name.Parent = row
-
-    local qty = Instance.new("TextLabel")
-    qty.Size = UDim2.new(0.4,-10,1,0)
-    qty.Position = UDim2.new(0.6,0,0,0)
-    qty.BackgroundTransparency = 1
-    qty.TextXAlignment = Enum.TextXAlignment.Right
-    qty.Font = Enum.Font.Gotham
-    qty.TextScaled = true
-    qty.TextColor3 = Color3.fromRGB(230,230,230)
-    qty.Text = string.format("%d / %d", it.qty, it.stack)
-    qty.Parent = row
-end
-
-function BootUI.populateBackpackUI(bp)
-    if backpackUI then
-        backpackUI:setData(bp)
-    end
-end
--- =====================
-btnBack.MouseButton1Click:Connect(function()
-    -- Return to picker; snap camera back to start
-    applyStartCam()
-    Cosmetics.showDojoPicker()
-end)
-
-btnEnterRealm.MouseButton1Click:Connect(function()
-    if not selectedRealm then return end
-    local realmName = selectedRealm
-    local displayName = realmDisplayLookup[selectedRealm]
-    DojoClient.start(displayName)
-    if realmName == "StarterDojo" then
-        TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
-        task.wait(0.28)
-
-        local personaType, chosenSlot = Cosmetics.getSelectedPersona()
-        if enterRE then
-            enterRE:FireServer({ type = personaType, slot = chosenSlot })
-        else
-            warn("EnterDojoRE missing on server")
-        end
-
-        -- wait for character and hand camera back to gameplay
-        task.wait(0.2)
-        local char = player.Character or player.CharacterAdded:Wait()
-        local hum = char:FindFirstChildOfClass("Humanoid")
-        cam.CameraType = Enum.CameraType.Custom
-        if hum then cam.CameraSubject = hum end
-
-        DojoClient.hide()
-        restoreUIBlur()
-        TweenService:Create(fade, TweenInfo.new(0.35), {BackgroundTransparency = 1}):Play()
-        task.delay(0.4, function()
-            if ui and ui.Parent then ui:Destroy() end
-            BootUI.destroy()
-        end)
-    else
-        local placeId = TeleportClient.WorldPlaceIds[realmName]
-        if not (placeId and placeId > 0) then
-            warn("No place id for realm: " .. tostring(realmName))
             DojoClient.hide()
-            return
+            restoreUIBlur()
+            TweenService:Create(fade, TweenInfo.new(0.35), {BackgroundTransparency = 1}):Play()
+            task.delay(0.4, function()
+                BootUI.hideOverlay()
+            end)
+        else
+            local placeId = TeleportClient.WorldPlaceIds[realmName]
+            if not (placeId and placeId > 0) then
+                warn("No place id for realm: " .. tostring(realmName))
+                DojoClient.hide()
+                return
+            end
+            TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
+            task.wait(0.28)
+            local _, chosenSlot = Cosmetics.getSelectedPersona()
+            DojoClient.hide()
+            local ok, err = pcall(function()
+                TeleportService:Teleport(placeId, player, {slot = chosenSlot})
+            end)
+            if not ok then warn("Teleport failed:", err) end
+            BootUI.hideOverlay()
         end
-        TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
-        task.wait(0.28)
-        local _, chosenSlot = Cosmetics.getSelectedPersona()
-        DojoClient.hide()
-        local ok, err = pcall(function()
-            TeleportService:Teleport(placeId, player, {slot = chosenSlot})
-        end)
-        if not ok then warn("Teleport failed:", err) end
-        BootUI.destroy()
-    end
 end)
-
+end
 -- Hook emote buttons once (after UI exists)
 -- =====================
 -- FLOW
@@ -622,17 +383,6 @@ Cosmetics.showDojoPicker()
 Cosmetics.refreshSlots(config.personaData)
 
 
-end
-
-function BootUI.destroy()
-    if BootUI.loadout then
-        BootUI.loadout:Destroy()
-        BootUI.loadout = nil
-    end
-    BootUI.buildCharacterPreview = nil
-    BootUI.currencyService = nil
-    BootUI.shop = nil
-    backpackUI = nil
 end
 
 return BootUI

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -232,26 +232,41 @@ refreshSlots = function(data)
 end
 
 local function showDojoPicker()
-	if dojo then dojo.Visible = true end
-	if boot then
-		if boot.loadout then boot.loadout.Visible = false end
-		if boot.shopBtn then boot.shopBtn.Visible = false end
-	end
+        if dojo then dojo.Visible = true end
+        if boot then
+                if boot.hideLoadout then
+                        boot.hideLoadout()
+                elseif boot.loadout then
+                        boot.loadout.Visible = false
+                end
+                if boot.setShopButtonVisible then
+                        boot.setShopButtonVisible(false)
+                elseif boot.shopBtn then
+                        boot.shopBtn.Visible = false
+                end
+        end
 end
 
 local function showLoadout(personaType)
-	if dojo then dojo.Visible = false end
-	if boot then
-		if boot.shopBtn then boot.shopBtn.Visible = true end
-		if boot.loadout then
-			boot.loadout.Visible = true
-			if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
-			if boot.populateBackpackUI then
-				local saved = player:GetAttribute("Inventory")
-				if typeof(saved) == "string" then
-					local ok, data = pcall(HttpService.JSONDecode, HttpService, saved)
-					if ok then
-						boot.populateBackpackUI(data)
+        if dojo then dojo.Visible = false end
+        if boot then
+                if boot.setShopButtonVisible then
+                        boot.setShopButtonVisible(true)
+                elseif boot.shopBtn then
+                        boot.shopBtn.Visible = true
+                end
+                if boot.showLoadout then
+                        boot.showLoadout()
+                elseif boot.loadout then
+                        boot.loadout.Visible = true
+                end
+                if boot.buildCharacterPreview then boot.buildCharacterPreview(personaType) end
+                if boot.populateBackpackUI then
+                                local saved = player:GetAttribute("Inventory")
+                                if typeof(saved) == "string" then
+                                        local ok, data = pcall(HttpService.JSONDecode, HttpService, saved)
+                                        if ok then
+                                                boot.populateBackpackUI(data)
 					end
 				elseif boot.StarterBackpack then
 					boot.populateBackpackUI(boot.StarterBackpack)
@@ -266,10 +281,9 @@ local function showLoadout(personaType)
 							end
 						end
 					end)
-				end
-			end
-		end
-	end
+                end
+        end
+end
 end
 
 function Cosmetics.getSelectedPersona()

--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -1,0 +1,445 @@
+local Players = game:GetService("Players")
+local GuiService = game:GetService("GuiService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local ShopUI = require(ReplicatedStorage.ClientModules.UI.ShopUI)
+local QuestUI = require(ReplicatedStorage.ClientModules.UI.QuestUI)
+local BackpackUI = require(ReplicatedStorage.ClientModules.UI.BackpackUI)
+local TeleportClient = require(ReplicatedStorage.ClientModules.TeleportClient)
+
+local WorldHUD = {}
+WorldHUD.__index = WorldHUD
+
+local currentHud
+
+local player = Players.LocalPlayer
+
+local REALM_INFO = {
+    {key = "StarterDojo",   name = "Starter Dojo"},
+    {key = "SecretVillage", name = "Secret Village of Elementara"},
+    {key = "Water",         name = "Water"},
+    {key = "Fire",          name = "Fire"},
+    {key = "Wind",          name = "Wind"},
+    {key = "Growth",        name = "Growth"},
+    {key = "Ice",           name = "Ice"},
+    {key = "Light",         name = "Light"},
+    {key = "Metal",         name = "Metal"},
+    {key = "Strength",      name = "Strength"},
+    {key = "Atoms",         name = "Atoms"},
+}
+
+local function track(self, conn)
+    if not conn then return end
+    table.insert(self._connections, conn)
+end
+
+local function createRealmButton(parent, info)
+    local btn = Instance.new("TextButton")
+    btn.Size = UDim2.new(0,160,1,0)
+    btn.Text = info.name
+    btn.Font = Enum.Font.Gotham
+    btn.TextScaled = true
+    btn.BackgroundColor3 = Color3.fromRGB(80,80,80)
+    btn.TextColor3 = Color3.fromRGB(170,170,170)
+    btn.AutoButtonColor = false
+    btn.Parent = parent
+    return btn
+end
+
+local function ensureParent()
+    local playerGui = player:FindFirstChildOfClass("PlayerGui")
+    if not playerGui then
+        playerGui = player:WaitForChild("PlayerGui")
+    end
+    return playerGui
+end
+
+local function getRealmFolder()
+    local realmsFolder = player:FindFirstChild("Realms")
+    if not realmsFolder then
+        local stats = player:FindFirstChild("Stats")
+        if stats then
+            realmsFolder = stats:FindFirstChild("Realms")
+        end
+    end
+    return realmsFolder
+end
+
+function WorldHUD.get()
+    if currentHud and currentHud._destroyed then
+        currentHud = nil
+    end
+    return currentHud
+end
+
+function WorldHUD.new(config, dependencies)
+    if currentHud and currentHud.gui and currentHud.gui.Parent then
+        if config then currentHud.config = config end
+        if dependencies then
+            if dependencies.shop then currentHud.shop = dependencies.shop end
+            if dependencies.currencyService then currentHud.currencyService = dependencies.currencyService end
+        end
+        return currentHud
+    elseif currentHud and (not currentHud.gui or not currentHud.gui.Parent) then
+        currentHud = nil
+    end
+
+    local self = setmetatable({}, WorldHUD)
+    self.config = config or {}
+    self.shop = dependencies and dependencies.shop or nil
+    self.currencyService = dependencies and dependencies.currencyService or nil
+    self._connections = {}
+    self._flagConnections = {}
+    self._destroyed = false
+
+    local playerGui = ensureParent()
+
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "WorldHUD"
+    gui.ResetOnSpawn = false
+    gui.IgnoreGuiInset = true
+    gui.DisplayOrder = 75
+    gui.Parent = playerGui
+    self.gui = gui
+
+    local root = Instance.new("Frame")
+    root.Name = "WorldHUDRoot"
+    root.Size = UDim2.fromScale(1,1)
+    root.BackgroundTransparency = 1
+    root.Parent = gui
+    self.root = root
+
+    -- Shop button and toggle logic
+    local shopButton = Instance.new("TextButton")
+    shopButton.Name = "ShopButton"
+    shopButton.Size = UDim2.fromScale(0.1,0.06)
+    shopButton.AnchorPoint = Vector2.new(1,1)
+    shopButton.Position = UDim2.fromScale(0.98,0.98)
+    shopButton.Text = "Shop"
+    shopButton.Font = Enum.Font.GothamSemibold
+    shopButton.TextScaled = true
+    shopButton.TextColor3 = Color3.new(1,1,1)
+    shopButton.BackgroundColor3 = Color3.fromRGB(50,120,255)
+    shopButton.AutoButtonColor = true
+    shopButton.ZIndex = 10
+    shopButton.Visible = false
+    shopButton.Parent = root
+    self.shopButton = shopButton
+
+    track(self, shopButton.Activated:Connect(function()
+        self:toggleShop()
+    end))
+
+    -- Teleport UI placeholders
+    local teleFrame = Instance.new("Frame")
+    teleFrame.Name = "TeleFrame"
+    teleFrame.Size = UDim2.fromScale(1,1)
+    teleFrame.BackgroundTransparency = 1
+    teleFrame.Visible = false
+    teleFrame.Parent = root
+
+    local zoneButtons = {"Atom","Fire","Grow","Ice","Light","Metal","Water","Wind","Dojo","Starter"}
+    for _, zone in ipairs(zoneButtons) do
+        local button = Instance.new("TextButton")
+        button.Name = zone .. "Button"
+        button.Size = UDim2.new(0,0,0,0)
+        button.Visible = false
+        button.Text = zone
+        button.Parent = teleFrame
+    end
+
+    local worldFrame = Instance.new("Frame")
+    worldFrame.Name = "WorldTeleFrame"
+    worldFrame.Size = UDim2.fromScale(1,1)
+    worldFrame.BackgroundTransparency = 1
+    worldFrame.Visible = false
+    worldFrame.Parent = root
+
+    local enterRealmButton = Instance.new("TextButton")
+    enterRealmButton.Name = "EnterRealmButton"
+    enterRealmButton.Size = UDim2.new(0,0,0,0)
+    enterRealmButton.Visible = false
+    enterRealmButton.Text = "Enter"
+    enterRealmButton.Parent = worldFrame
+    self.enterRealmButton = enterRealmButton
+
+    for realmName, _ in pairs(TeleportClient.worldSpawnIds) do
+        local button = Instance.new("TextButton")
+        button.Name = realmName .. "Button"
+        button.Size = UDim2.new(0,0,0,0)
+        button.Visible = false
+        button.Text = realmName
+        button.Parent = worldFrame
+    end
+
+    TeleportClient.bindZoneButtons(root)
+    TeleportClient.bindWorldButtons(root)
+
+    -- Loadout UI
+    local loadout = Instance.new("Frame")
+    loadout.Name = "Loadout"
+    loadout.Size = UDim2.fromScale(1,1)
+    loadout.BackgroundTransparency = 1
+    loadout.Visible = false
+    loadout.ZIndex = 20
+    loadout.Parent = root
+    self.loadout = loadout
+
+    local baseY = GuiService:GetGuiInset().Y + 20
+    self.baseY = baseY
+
+    local loadTitle = Instance.new("TextLabel")
+    loadTitle.Size = UDim2.new(1,-40,0,60)
+    loadTitle.Position = UDim2.new(0.5,0,0,baseY)
+    loadTitle.AnchorPoint = Vector2.new(0.5,0)
+    loadTitle.BackgroundTransparency = 0.6
+    loadTitle.TextXAlignment = Enum.TextXAlignment.Center
+    loadTitle.Text = "Loadout"
+    loadTitle.Font = Enum.Font.GothamBold
+    loadTitle.TextScaled = true
+    loadTitle.TextColor3 = Color3.fromRGB(255,200,120)
+    loadTitle.Parent = loadout
+
+    local quest = QuestUI.init(loadout, baseY)
+    self.quest = quest
+
+    local backpack = BackpackUI.init(loadout, baseY)
+    self.backpack = backpack
+
+    local btnRow = Instance.new("Frame")
+    btnRow.Size = UDim2.new(1,-40,0,60)
+    btnRow.Position = UDim2.new(0,20,1,-80)
+    btnRow.BackgroundTransparency = 1
+    btnRow.Parent = loadout
+
+    local function makeAction(text, rightAlign)
+        local b = Instance.new("TextButton")
+        b.Size = UDim2.new(0,240,1,0)
+        b.Position = rightAlign and UDim2.new(1,-250,0,0) or UDim2.fromOffset(0,0)
+        b.AnchorPoint = rightAlign and Vector2.new(1,0) or Vector2.new(0,0)
+        b.Text = text
+        b.Font = Enum.Font.GothamSemibold
+        b.TextScaled = true
+        b.TextColor3 = Color3.new(1,1,1)
+        b.BackgroundColor3 = Color3.fromRGB(50,120,255)
+        b.AutoButtonColor = true
+        b.Parent = btnRow
+        return b
+    end
+
+    local btnBack = makeAction("Back", false)
+    local btnEnterRealm = makeAction("Enter Realm", true)
+    self.backButton = btnBack
+    self.enterRealmButton = btnEnterRealm
+
+    local realmScroll = Instance.new("ScrollingFrame")
+    realmScroll.Size = UDim2.new(1,-500,1,0)
+    realmScroll.Position = UDim2.fromOffset(250,-100)
+    realmScroll.BackgroundTransparency = 1
+    realmScroll.ScrollBarThickness = 6
+    realmScroll.CanvasSize = UDim2.new()
+    realmScroll.Parent = btnRow
+    local realmLayout = Instance.new("UIListLayout", realmScroll)
+    realmLayout.FillDirection = Enum.FillDirection.Horizontal
+    realmLayout.Padding = UDim.new(0,6)
+    track(self, realmLayout:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+        realmScroll.CanvasSize = UDim2.new(0, realmLayout.AbsoluteContentSize.X, 0, 0)
+    end))
+
+    local realmButtons = {}
+    self.realmButtons = realmButtons
+    local realmDisplayLookup = {}
+    self.realmDisplayLookup = realmDisplayLookup
+    for _, info in ipairs(REALM_INFO) do
+        realmDisplayLookup[info.key] = info.name
+    end
+
+    local function isRealmUnlocked(key)
+        local realmsFolder = getRealmFolder()
+        if not realmsFolder then return false end
+        local flag = realmsFolder:FindFirstChild(key)
+        return flag and flag.Value or false
+    end
+
+    local function updateRealmButton(key)
+        local btn = realmButtons[key]
+        if not btn then return end
+        local unlocked = isRealmUnlocked(key)
+        btn.Active = unlocked
+        btn.AutoButtonColor = unlocked
+        btn.BackgroundColor3 = unlocked and Color3.fromRGB(50,120,255) or Color3.fromRGB(80,80,80)
+        btn.TextColor3 = unlocked and Color3.new(1,1,1) or Color3.fromRGB(170,170,170)
+    end
+
+    local function setSelected(key)
+        self.selectedRealm = key
+        for k, b in pairs(realmButtons) do
+            if k == key then
+                b.BackgroundColor3 = Color3.fromRGB(80,160,255)
+            else
+                updateRealmButton(k)
+            end
+        end
+        local hasPlace = (key == "StarterDojo") or (TeleportClient.WorldPlaceIds[key] and TeleportClient.WorldPlaceIds[key] > 0)
+        btnEnterRealm.Active = hasPlace
+        btnEnterRealm.AutoButtonColor = hasPlace
+        btnEnterRealm.BackgroundColor3 = hasPlace and Color3.fromRGB(50,120,255) or Color3.fromRGB(80,80,80)
+        btnEnterRealm.Text = "Enter " .. (realmDisplayLookup[key] or "Realm")
+    end
+    self._setSelectedRealm = setSelected
+
+    for _, info in ipairs(REALM_INFO) do
+        local btn = createRealmButton(realmScroll, info)
+        realmButtons[info.key] = btn
+        track(self, btn.Activated:Connect(function()
+            if not btn.Active then return end
+            setSelected(info.key)
+        end))
+        local realmsFolder = getRealmFolder()
+        if realmsFolder then
+            local flag = realmsFolder:FindFirstChild(info.key)
+            if flag then
+                local conn = flag:GetPropertyChangedSignal("Value"):Connect(function()
+                    updateRealmButton(info.key)
+                end)
+                self._flagConnections[#self._flagConnections + 1] = conn
+            end
+        end
+        updateRealmButton(info.key)
+    end
+
+    btnEnterRealm.Active = false
+    btnEnterRealm.AutoButtonColor = false
+
+    local realmsFolder = getRealmFolder()
+    if realmsFolder then
+        track(self, realmsFolder.ChildAdded:Connect(function(child)
+            local btn = realmButtons[child.Name]
+            if btn then
+                local conn = child:GetPropertyChangedSignal("Value"):Connect(function()
+                    updateRealmButton(child.Name)
+                end)
+                self._flagConnections[#self._flagConnections + 1] = conn
+                updateRealmButton(child.Name)
+            end
+        end))
+    end
+
+    if self.config and self.config.showShop then
+        self:toggleShop()
+    end
+
+    currentHud = self
+    return self
+end
+
+function WorldHUD:getLoadoutFrame()
+    return self.loadout
+end
+
+function WorldHUD:getShopButton()
+    return self.shopButton
+end
+
+function WorldHUD:getQuestInterface()
+    return self.quest
+end
+
+function WorldHUD:getBackpackInterface()
+    return self.backpack
+end
+
+function WorldHUD:setShopButtonVisible(visible)
+    if self.shopButton then
+        self.shopButton.Visible = visible and true or false
+    end
+end
+
+function WorldHUD:showLoadout()
+    if self.loadout then
+        self.loadout.Visible = true
+    end
+    self:setShopButtonVisible(true)
+end
+
+function WorldHUD:hideLoadout()
+    if self.loadout then
+        self.loadout.Visible = false
+    end
+    self:setShopButtonVisible(false)
+end
+
+function WorldHUD:toggleShop(defaultTab)
+    if not self.shop then
+        warn("WorldHUD: shop instance missing")
+        return
+    end
+    if not self.shopFrame or not self.shopFrame.Parent then
+        local fakeBoot = {root = self.root}
+        self.shopFrame = ShopUI.init(self.config, self.shop, fakeBoot, defaultTab)
+    else
+        self.shopFrame.Visible = not self.shopFrame.Visible
+    end
+    if self.shopFrame and self.shopFrame.Visible and defaultTab and ShopUI.setTab then
+        ShopUI.setTab(defaultTab)
+    end
+    return self.shopFrame and self.shopFrame.Visible
+end
+
+function WorldHUD:setBackpackData(data)
+    if self.backpack and self.backpack.setData then
+        self.backpack:setData(data)
+    end
+end
+
+function WorldHUD:updateCurrency(coins, orbs, elements)
+    if self.backpack and self.backpack.updateCurrency then
+        self.backpack:updateCurrency(coins, orbs, elements)
+    end
+end
+
+function WorldHUD:getSelectedRealm()
+    return self.selectedRealm
+end
+
+function WorldHUD:getRealmDisplayName(key)
+    return self.realmDisplayLookup and self.realmDisplayLookup[key]
+end
+
+function WorldHUD:setSelectedRealm(key)
+    if self._setSelectedRealm then
+        self._setSelectedRealm(key)
+    end
+end
+
+function WorldHUD:destroy()
+    if self._destroyed then return end
+    self._destroyed = true
+    for _, conn in ipairs(self._connections) do
+        if conn.Disconnect then conn:Disconnect() end
+    end
+    for _, conn in ipairs(self._flagConnections) do
+        if conn.Disconnect then conn:Disconnect() end
+    end
+    self._connections = {}
+    self._flagConnections = {}
+    if self.gui then
+        self.gui:Destroy()
+    end
+    self.gui = nil
+    self.root = nil
+    self.loadout = nil
+    self.shopButton = nil
+    self.shopFrame = nil
+    self.backButton = nil
+    self.enterRealmButton = nil
+    self.quest = nil
+    self.backpack = nil
+    self._setSelectedRealm = nil
+    if currentHud == self then
+        currentHud = nil
+    end
+end
+
+return WorldHUD
+

--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -13,6 +13,8 @@ local HapticService = game:GetService("HapticService")
 local Abilities = require(ReplicatedStorage.ClientModules.Abilities)
 local CombatController = require(ReplicatedStorage.ClientModules.CombatController)
 local GameSettings = require(ReplicatedStorage.GameSettings)
+local WorldHUD = require(ReplicatedStorage.ClientModules.UI.WorldHUD)
+local hud = WorldHUD.get()
 
 -- UI Configuration (Expanded with more options)
 local UI_CONFIG = {


### PR DESCRIPTION
## Summary
- extract the loadout, shop, teleport, and backpack construction into a new `WorldHUD` client module that exposes show/hide/toggle helpers
- update `BootUI` to initialize the shared HUD alongside the intro overlay and expose helper methods while keeping the boot camera/transition logic intact
- switch cosmetics and the main gameplay script to use the shared HUD APIs so the UI instance can persist between worlds

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce498cacd88332950bfeb3816c3eda