### PR TITLE
Refactor cosmetics to use callback interface

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -184,6 +184,48 @@ local StarterBackpack = config.inventory or config.starterBackpack or {
 BootUI.StarterBackpack = StarterBackpack
 BootUI.personaData = config.personaData
 
+local cosmeticsInterface = {}
+if hud and hud.createCosmeticsInterface then
+    cosmeticsInterface = hud:createCosmeticsInterface() or {}
+end
+
+if not cosmeticsInterface.showDojoPicker then
+    cosmeticsInterface.showDojoPicker = function()
+        BootUI.hideLoadout()
+        BootUI.setShopButtonVisible(false)
+    end
+end
+
+if not cosmeticsInterface.showLoadout then
+    cosmeticsInterface.showLoadout = function(personaType)
+        BootUI.showLoadout()
+        BootUI.setShopButtonVisible(true)
+    end
+end
+
+if not cosmeticsInterface.updateBackpack then
+    cosmeticsInterface.updateBackpack = function(data)
+        BootUI.populateBackpackUI(data)
+    end
+end
+
+if not cosmeticsInterface.buildCharacterPreview then
+    cosmeticsInterface.buildCharacterPreview = function(personaType)
+        local builder = BootUI.buildCharacterPreview
+        if builder then
+            builder(personaType)
+        end
+    end
+end
+
+if not cosmeticsInterface.getStarterBackpack then
+    cosmeticsInterface.getStarterBackpack = function()
+        return BootUI.StarterBackpack
+    end
+end
+
+BootUI.cosmeticsInterface = cosmeticsInterface
+
 
 -- =====================
 -- Camera helpers (world)
@@ -242,6 +284,10 @@ local function tweenToEnd()
     TweenService:Create(cam, TweenInfo.new(CAM_TWEEN_TIME, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {CFrame = cf, FieldOfView = fov}):Play()
 end
 BootUI.tweenToEnd = tweenToEnd
+
+if not cosmeticsInterface.tweenToEnd then
+    cosmeticsInterface.tweenToEnd = tweenToEnd
+end
 
 -- Lighting helpers (disable DOF while UI is visible)
 -- =====================
@@ -303,7 +349,7 @@ root.BackgroundTransparency = 1
 root.Parent = ui
 
 BootUI.root = root
-Cosmetics.init(config, root, BootUI)
+Cosmetics.init(config, root, cosmeticsInterface)
 
 -- Intro visuals
 local fade = Instance.new("Frame")

--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -349,6 +349,32 @@ function WorldHUD:getBackpackInterface()
     return self.backpack
 end
 
+function WorldHUD:createCosmeticsInterface()
+    local hud = self
+    return {
+        showDojoPicker = function()
+            if hud and hud.hideLoadout then
+                hud:hideLoadout()
+            end
+        end,
+        showLoadout = function(personaType)
+            if hud and hud.showLoadout then
+                hud:showLoadout()
+            end
+        end,
+        updateBackpack = function(data)
+            if hud and hud.setBackpackData then
+                hud:setBackpackData(data)
+            end
+        end,
+        buildCharacterPreview = function(personaType)
+            if hud and hud.quest and hud.quest.buildCharacterPreview then
+                hud.quest.buildCharacterPreview(personaType)
+            end
+        end,
+    }
+end
+
 function WorldHUD:setShopButtonVisible(visible)
     if self.shopButton then
         self.shopButton.Visible = visible and true or false


### PR DESCRIPTION
## Summary
- refactor `Cosmetics` to accept an injected interface and call explicit callbacks instead of BootUI internals
- build the cosmetics callback interface in `BootUI.start`, wiring HUD behavior, starter backpack access, and tween handling
- expose `WorldHUD:createCosmeticsInterface` so BootUI can source the loadout, dojo, backpack, and preview callbacks from the HUD

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce4d01bd7c83328dffd02a6aef44f3