### PR TITLE
Update combat strike sound asset

### DIFF
--- a/ReplicatedStorage/ClientModules/CombatController.lua
+++ b/ReplicatedStorage/ClientModules/CombatController.lua
@@ -25,7 +25,7 @@ local slideSpeedMultiplier = 1.25
 local canStrike = true
 local animationTracks = {}
 local STRIKE_SOUND_NAME = "Combat_Strike_SFX"
-local STRIKE_SOUND_ID = 9118820981
+local STRIKE_SOUND_ID = 12222216
 
 AudioPlayer.preloadAudio({ [STRIKE_SOUND_NAME] = STRIKE_SOUND_ID })
 


### PR DESCRIPTION
## Summary
- replace the combat strike sound configuration with a known Roblox strike audio asset ID
- keep the existing preload/playback logic unchanged so the updated sound is still preloaded by the audio system

## Testing
- not run (Roblox Studio unavailable in container environment)

------
https://chatgpt.com/codex/tasks/task_e_68cf883441188332bf43f9326f1cbf41