### PR TITLE
Improve ShopItems module loading

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/ShopUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/ShopUI.lua
@@ -6,10 +6,20 @@ local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 -- shop UI can still be created even if the module is missing. Returning nil
 -- from this module would cause requires to fail in BootUI.
 local ShopItems = {Elements = {}, Weapons = {}}
-local ok, shopItemsModule = pcall(function()
-    return bootModules:WaitForChild("ShopItems", 10)
-end)
-if ok and shopItemsModule then
+local function waitForShopItemsModule()
+    local module = bootModules:FindFirstChild("ShopItems")
+    while not module do
+        if not bootModules.Parent or not bootModules:IsDescendantOf(game) then
+            return nil
+        end
+        task.wait()
+        module = bootModules:FindFirstChild("ShopItems")
+    end
+    return module
+end
+
+local shopItemsModule = waitForShopItemsModule()
+if shopItemsModule then
     local success, items = pcall(require, shopItemsModule)
     if success and typeof(items) == "table" then
         ShopItems = items

--- a/ServerScriptService/ShopScript.lua
+++ b/ServerScriptService/ShopScript.lua
@@ -13,10 +13,20 @@ local bootModules = ReplicatedStorage:WaitForChild("BootModules")
 -- Load ShopItems if available; otherwise continue with an empty list so the
 -- server script doesn't abort during startup.
 local ShopItems = {}
-local ok, shopItemsModule = pcall(function()
-    return bootModules:WaitForChild("ShopItems", 10)
-end)
-if ok and shopItemsModule then
+local function waitForShopItemsModule()
+    local module = bootModules:FindFirstChild("ShopItems")
+    while not module do
+        if not bootModules.Parent or not bootModules:IsDescendantOf(game) then
+            return nil
+        end
+        task.wait()
+        module = bootModules:FindFirstChild("ShopItems")
+    end
+    return module
+end
+
+local shopItemsModule = waitForShopItemsModule()
+if shopItemsModule then
     local success, items = pcall(require, shopItemsModule)
     if success and typeof(items) == "table" then
         ShopItems = items


### PR DESCRIPTION
## Summary
- wait for the ShopItems module to actually appear on both the server and client before requiring it
- retain the empty-table fallback but only warn when the module is definitively unavailable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf88327158833282244f4d97a3236f