### PR TITLE
Start Boot UI immediately and update once data loads

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -168,6 +168,27 @@ function BootUI.populateBackpackUI(data)
     end
 end
 
+function BootUI.applyFetchedData(data)
+    data = data or {}
+
+    BootUI.config = BootUI.config or {}
+
+    local inventory = data.inventory
+    if typeof(inventory) == "table" then
+        BootUI.config.inventory = inventory
+        BootUI.StarterBackpack = inventory
+        BootUI.populateBackpackUI(inventory)
+    end
+
+    local personaData = data.personaData
+    if personaData ~= nil then
+        local sanitized = sanitizePersonaData(personaData)
+        BootUI.config.personaData = sanitized
+        BootUI.personaData = sanitized
+        Cosmetics.refreshSlots(sanitized)
+    end
+end
+
 function BootUI.getSelectedRealm()
     local hud = BootUI.hud
     if hud and hud.getSelectedRealm then
@@ -294,6 +315,8 @@ if not cosmeticsInterface.getStarterBackpack then
 end
 
 BootUI.cosmeticsInterface = cosmeticsInterface
+
+BootUI.populateBackpackUI(config.inventory)
 
 
 -- =====================

--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -18,5 +18,9 @@ PersonaUI.start({waitTime = 0})
 local DojoClient = require(BootModules.DojoClient)
 
 local BootUI = require(BootModules.BootUI)
-local config = BootUI.fetchData()
-BootUI.start(config)
+BootUI.start()
+
+task.spawn(function()
+    local data = BootUI.fetchData()
+    BootUI.applyFetchedData(data)
+end)


### PR DESCRIPTION
## Summary
- start the boot UI without waiting for persona data to return from the server so the initial camera activates right away
- add an `applyFetchedData` helper so inventory and persona slots update once the remote call completes
- update the boot UI to refresh backpack contents after initialization

## Testing
- not run (Roblox environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4f3f6cbe483328454bd5e496b2e51