### PR TITLE
Ensure Boot UI waits for PlayerGui

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -17,6 +17,29 @@ local rf      = nil
 local cam     = Workspace.CurrentCamera
 local enterRE = ReplicatedStorage:FindFirstChild("EnterDojoRE") -- created by server script
 
+local function getPlayerGui()
+    if not player then
+        player = Players.LocalPlayer
+    end
+    if not player then
+        return nil
+    end
+
+    local gui = player:FindFirstChildOfClass("PlayerGui")
+    if gui then
+        return gui
+    end
+
+    local ok, result = pcall(function()
+        return player:WaitForChild("PlayerGui", 5)
+    end)
+    if ok and result then
+        return result
+    end
+
+    return nil
+end
+
 local GameSettings = require(ReplicatedStorage.GameSettings)
 local DEFAULT_SLOT_COUNT = tonumber(GameSettings.maxSlots) or 3
 
@@ -432,7 +455,17 @@ ui.ResetOnSpawn   = false
 ui.Name           = "IntroGui"
 ui.IgnoreGuiInset = true
 ui.DisplayOrder   = 100
-ui.Parent         = player.PlayerGui
+local playerGuiParent = getPlayerGui()
+if playerGuiParent then
+    ui.Parent = playerGuiParent
+else
+    task.spawn(function()
+        local target = getPlayerGui()
+        if target then
+            ui.Parent = target
+        end
+    end)
+end
 BootUI.introGui   = ui
 
 local root = Instance.new("Frame")


### PR DESCRIPTION
## Summary
- ensure the boot UI waits for the player's PlayerGui before parenting the intro screen
- add a deferred retry so the overlay attaches once the PlayerGui becomes available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4f80ebd24833298b813ea9bb1a408