### PR TITLE
Improve persona loading debug experience

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/Boot.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/Boot.client.lua
@@ -13,12 +13,13 @@ if not blur then
 end
 
 local PersonaUI = require(BootModules.PersonaUI)
-PersonaUI.start({waitTime = 0})
+PersonaUI.start({waitTime = 0, fadeTime = 0})
 
 local DojoClient = require(BootModules.DojoClient)
 
 local BootUI = require(BootModules.BootUI)
 BootUI.start()
+BootUI.setDebugLine("status", "Initializing profile fetch…")
 
 task.spawn(function()
     local data = BootUI.fetchData()


### PR DESCRIPTION
## Summary
- add an on-screen debug panel during boot that tracks player info, persona data, and remote availability
- decode cached inventory and persona payloads while updating the debug display with main persona stats
- speed up the intro by skipping the PersonaUI fade and shortening the start camera hold so the persona picker appears faster

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4fc21ace883328c558b7e935df4d1