### PR TITLE
Clarify ShopItems module placement

### DIFF
--- a/ReplicatedStorage/BootModules/ShopItems.lua
+++ b/ReplicatedStorage/BootModules/ShopItems.lua
@@ -1,3 +1,6 @@
+-- Item definitions exposed to both server and client boot modules.
+-- Keeping this module in ReplicatedStorage/BootModules ensures Roblox Studio
+-- exports it with the exact "ShopItems" name required at runtime.
 local ShopItems = {
     Elements = {
         Fire = {cost = 100},


### PR DESCRIPTION
## Summary
- note why the ShopItems boot module must remain in ReplicatedStorage/BootModules so it keeps the required name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60750babc8332b7d9c22fc29955c0