### PR TITLE
Fix invalid UIListLayout alignment

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -326,7 +326,7 @@ function WorldHUD.new(config, dependencies)
     local worldLayout = Instance.new("UIListLayout")
     worldLayout.FillDirection = Enum.FillDirection.Vertical
     worldLayout.Padding = UDim.new(0, 8)
-    worldLayout.HorizontalAlignment = Enum.HorizontalAlignment.Stretch
+    worldLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
     worldLayout.SortOrder = Enum.SortOrder.LayoutOrder
     worldLayout.Parent = worldFrame
 


### PR DESCRIPTION
## Summary
- replace the invalid `Enum.HorizontalAlignment.Stretch` assignment with `Enum.HorizontalAlignment.Left` in the world HUD list layout
- prevent runtime errors caused by using a nonexistent enum value when building the world teleport UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60dc254bc8332ada89481e22ce1e7