### PR TITLE
Handle missing HorizontalAlignment.Stretch enum

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -37,6 +37,18 @@ local function track(self, conn)
     return conn
 end
 
+local function getEnumValue(enumType, itemName, fallback)
+    local ok, value = pcall(function()
+        return enumType[itemName]
+    end)
+
+    if ok and value ~= nil then
+        return value
+    end
+
+    return fallback
+end
+
 local function createRealmButton(parent, info, order)
     local btn = Instance.new("TextButton")
     btn.Name = info.key .. "Button"
@@ -326,7 +338,7 @@ function WorldHUD.new(config, dependencies)
     local worldLayout = Instance.new("UIListLayout")
     worldLayout.FillDirection = Enum.FillDirection.Vertical
     worldLayout.Padding = UDim.new(0, 8)
-    worldLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    worldLayout.HorizontalAlignment = getEnumValue(Enum.HorizontalAlignment, "Stretch", Enum.HorizontalAlignment.Left)
     worldLayout.SortOrder = Enum.SortOrder.LayoutOrder
     worldLayout.Parent = worldFrame
 


### PR DESCRIPTION
## Summary
- add a utility to safely fetch enum members in WorldHUD
- fall back to the existing Left alignment when HorizontalAlignment.Stretch is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60e645e588332b242b1345e11aea9