### PR TITLE
Set WorldHUD ScreenGui to use global z-index

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -85,13 +85,14 @@ function WorldHUD.new(config, dependencies)
 
 	local playerGui = ensureParent()
 
-	local gui = Instance.new("ScreenGui")
-	gui.Name = "WorldHUD"
-	gui.ResetOnSpawn = false
-	gui.IgnoreGuiInset = true
-	gui.DisplayOrder = 75
-	gui.Parent = playerGui
-	self.gui = gui
+        local gui = Instance.new("ScreenGui")
+        gui.Name = "WorldHUD"
+        gui.ResetOnSpawn = false
+        gui.IgnoreGuiInset = true
+        gui.ZIndexBehavior = Enum.ZIndexBehavior.Global
+        gui.DisplayOrder = 75
+        gui.Parent = playerGui
+        self.gui = gui
 
 	local root = Instance.new("Frame")
 	root.Name = "WorldHUDRoot"


### PR DESCRIPTION
## Summary
- ensure the WorldHUD ScreenGui opts into global z-index behavior so its Teleport UI renders above other HUD elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6252987e48332a0b29419b7e18da9