### PR TITLE
Align quest and pouch panels

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
@@ -31,8 +31,8 @@ function NinjaPouchUI.init(parent, baseY)
     -- Main pouch container
     local pouch = Instance.new("Frame")
     pouch.Name = "NinjaPouch"
-    pouch.Size = UDim2.new(0.45, -20, 0.65, 0)
-    pouch.Position = UDim2.new(1, -15, 0, baseY + 80)
+    pouch.Size = UDim2.new(0.47, -20, 0.65, 0)
+    pouch.Position = UDim2.new(1, -20, 0, baseY + 80)
     pouch.AnchorPoint = Vector2.new(1, 0)
     pouch.BackgroundColor3 = Color3.fromRGB(15, 15, 20)
     pouch.BackgroundTransparency = 0.1

--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -54,8 +54,8 @@ function QuestUI.init(parent, baseY)
 
     local vpCard = Instance.new("Frame")
     vpCard.BackgroundTransparency = 0.6
-    vpCard.Size = UDim2.new(0.48,-30,0.62,0)
-    vpCard.Position = UDim2.fromOffset(20, baseY + 92)
+    vpCard.Size = UDim2.new(0.47, -20, 0.65, 0)
+    vpCard.Position = UDim2.fromOffset(20, baseY + 80)
     vpCard.BackgroundColor3 = Color3.fromRGB(24,26,28)
     vpCard.BorderSizePixel = 0
     vpCard.Parent = questRoot


### PR DESCRIPTION
## Summary
- adjust the quest viewport card to share the new panel dimensions and top inset
- resize and reposition the pouch panel to mirror the quest panel margins

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d625f131948332bce02c82cce9e63c