### PR TITLE
Enable viewport interaction for quest preview

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -167,6 +167,8 @@ function QuestUI.init(parent, baseY)
     viewport.BackgroundTransparency = 0.2
     viewport.BorderSizePixel = 0
     viewport.ZIndex = 7
+    viewport.Active = true
+    viewport.Selectable = false
     viewport.Parent = viewportContainer
     createCorner(viewport, 6)
 


### PR DESCRIPTION
## Summary
- activate the quest character viewport frame so it can capture drag input for orbit controls

## Testing
- not run (not run in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d62f8699d88332856cff1599332778