### PR TITLE
Add scrolling for NinjaQuest emote buttons

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -92,12 +92,17 @@ function QuestUI.init(parent, baseY)
     closeButton.Parent = previewHeader
     createCorner(closeButton, 10)
 
-    local emoteContainer = Instance.new("Frame")
+    local emoteContainer = Instance.new("ScrollingFrame")
     emoteContainer.Name = "EmoteButtonRow"
     emoteContainer.Size = UDim2.new(1, -20, 0, 46)
     emoteContainer.Position = UDim2.new(0, 10, 0, 55)
     emoteContainer.BackgroundTransparency = 1
     emoteContainer.ZIndex = 6
+    emoteContainer.ScrollingDirection = Enum.ScrollingDirection.X
+    emoteContainer.AutomaticCanvasSize = Enum.AutomaticSize.X
+    emoteContainer.CanvasSize = UDim2.new(0, 0, 0, 46)
+    emoteContainer.ScrollBarThickness = 4
+    emoteContainer.ClipsDescendants = true
     emoteContainer.Parent = previewCard
 
     local emoteLayout = Instance.new("UIListLayout")


### PR DESCRIPTION
## Summary
- convert the NinjaQuest emote button row into a scrolling frame so the buttons stay within the card
- enable horizontal scrolling with automatic canvas sizing to keep the emotes accessible on smaller screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d63309e7588332abfd537e910e9efd