### PR TITLE
Add teleport callbacks to hide Teleport UI when traveling

### DIFF
--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -85,11 +85,14 @@ local function teleportToPlace(placeId)
 	resetDebounceAfter(2)
 end
 
-function TeleportClient.bindZoneButtons(gui)
+function TeleportClient.bindZoneButtons(gui, callbacks)
         if not gui then
                 warn("TeleportClient: gui parameter missing for zone buttons")
                 return
         end
+
+        callbacks = callbacks or {}
+        local onTeleport = callbacks.onTeleport
 
         local teleFrame = gui:FindFirstChild("TeleFrame", true)
         if not teleFrame then
@@ -114,6 +117,9 @@ function TeleportClient.bindZoneButtons(gui)
                 local button = teleFrame:FindFirstChild(name .. "Button")
                 if button then
                         button.Activated:Connect(function()
+                                if onTeleport then
+                                        onTeleport()
+                                end
                                 teleportToIsland(unpack(zoneInfo))
                         end)
                 else
@@ -123,11 +129,14 @@ function TeleportClient.bindZoneButtons(gui)
 end
 
 
-function TeleportClient.bindWorldButtons(gui)
+function TeleportClient.bindWorldButtons(gui, callbacks)
         if not gui then
                 warn("TeleportClient: gui parameter missing for world buttons")
                 return
         end
+
+       callbacks = callbacks or {}
+       local onTeleport = callbacks.onTeleport
 
        local worldFrame = gui:FindFirstChild("WorldTeleFrame", true)
        if not worldFrame then
@@ -351,6 +360,9 @@ function TeleportClient.bindWorldButtons(gui)
                if not selectedRealm then return end
                local placeId = TeleportClient.worldSpawnIds[selectedRealm]
                if placeId and placeId > 0 then
+                       if onTeleport then
+                               onTeleport()
+                       end
                        teleportToPlace(placeId)
                else
                        warn("TeleportClient: missing asset id for realm " .. tostring(selectedRealm))
@@ -358,17 +370,17 @@ function TeleportClient.bindWorldButtons(gui)
        end)
 end
 
-function TeleportClient.init(gui)
+function TeleportClient.init(gui, callbacks)
         if not gui then
                 warn("TeleportClient: gui parameter is required")
                 return
         end
 
         if gui:FindFirstChild("TeleFrame", true) then
-                TeleportClient.bindZoneButtons(gui)
+                TeleportClient.bindZoneButtons(gui, callbacks)
         end
         if gui:FindFirstChild("WorldTeleFrame", true) then
-                TeleportClient.bindWorldButtons(gui)
+                TeleportClient.bindWorldButtons(gui, callbacks)
         end
 end
 

--- a/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
@@ -131,6 +131,7 @@ function TeleportUI.init(parent, baseY, dependencies)
         self.selectedRealm = nil
         self.realmInfo = dependencies.REALM_INFO or DEFAULT_REALM_INFO
         self.getRealmFolder = dependencies.getRealmFolder or defaultGetRealmFolder
+        self.onTeleport = dependencies.onTeleport
 
         local teleportContainer = Instance.new("Frame")
         teleportContainer.Name = "TeleportContainer"
@@ -474,8 +475,13 @@ function TeleportUI.init(parent, baseY, dependencies)
                 self:setVisible(false)
         end))
 
-        TeleportClient.bindZoneButtons(teleportContainer)
-        TeleportClient.bindWorldButtons(teleportContainer)
+        local teleportCallbacks
+        if self.onTeleport then
+                teleportCallbacks = {onTeleport = self.onTeleport}
+        end
+
+        TeleportClient.bindZoneButtons(teleportContainer, teleportCallbacks)
+        TeleportClient.bindWorldButtons(teleportContainer, teleportCallbacks)
 
         return self
 end

--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -127,10 +127,15 @@ function WorldHUD.new(config, dependencies)
 	loadTitle.Parent = loadout
 
 	-- Teleport UI
-	local teleportUI = TeleportUI.init(loadout, baseY, {
-		REALM_INFO = REALM_INFO,
-		getRealmFolder = getRealmFolder,
-	})
+        local setTeleportsVisible
+
+        local teleportUI = TeleportUI.init(loadout, baseY, {
+                REALM_INFO = REALM_INFO,
+                getRealmFolder = getRealmFolder,
+                onTeleport = function()
+                        setTeleportsVisible(false)
+                end,
+        })
 	self.teleportUI = teleportUI
 	local teleportCloseButton = teleportUI and teleportUI.closeButton or nil
 	self.teleportCloseButton = teleportCloseButton
@@ -185,12 +190,12 @@ function WorldHUD.new(config, dependencies)
 	self.teleportOpenButton = teleOpenButton
 	self.shopButton = shopButton
 
-	local function setTeleportsVisible(visible)
-		if teleportUI then
-			teleportUI:setVisible(visible)
-		end
-		teleOpenButton.Visible = not visible
-	end
+        setTeleportsVisible = function(visible)
+                if teleportUI then
+                        teleportUI:setVisible(visible)
+                end
+                teleOpenButton.Visible = not visible
+        end
 
 	if quest and quest.closeButton then
 		track(self, quest.closeButton.MouseButton1Click:Connect(function()


### PR DESCRIPTION
## Summary
- propagate an optional teleport callback from the World HUD into the Teleport UI bindings
- invoke the callback before triggering island or realm teleports so the UI can hide and toggles reappear

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63ae3780c8332a92098a664bc4867