### PR TITLE
Restore HUD after dojo entry fade

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -737,7 +737,17 @@ if enterRealmButton then
 
             DojoClient.hide()
             restoreUIBlur()
-            TweenService:Create(fade, TweenInfo.new(0.35), {BackgroundTransparency = 1}):Play()
+            local fadeTween = TweenService:Create(fade, TweenInfo.new(0.35), {BackgroundTransparency = 1})
+            fadeTween.Completed:Connect(function(playbackState)
+                if playbackState == Enum.PlaybackState.Completed then
+                    BootUI.showLoadout()
+                    local currentHud = BootUI.hud
+                    if currentHud and currentHud.setBackButtonEnabled then
+                        currentHud:setBackButtonEnabled(true)
+                    end
+                end
+            end)
+            fadeTween:Play()
             task.delay(0.4, function()
                 BootUI.hideOverlay()
             end)


### PR DESCRIPTION
## Summary
- show the world HUD again after the in-place dojo entry fade completes
- re-enable the HUD back button alongside the loadout restore

## Testing
- not run (Roblox Studio not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d64049493c8332bf5c601e1078ca12