### PR TITLE
Restyle close buttons with ninja circles

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/NinjaMarketplaceUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaMarketplaceUI.lua
@@ -52,23 +52,56 @@ local function createStroke(parent, thickness, color)
 end
 
 local function createGradient(parent, colors, transparency)
-	local gradient = Instance.new("UIGradient")
-	gradient.Color = colors or ColorSequence.new{
-		ColorSequenceKeypoint.new(0, Color3.fromRGB(25, 25, 35)),
-		ColorSequenceKeypoint.new(1, Color3.fromRGB(15, 15, 25))
+        local gradient = Instance.new("UIGradient")
+        gradient.Color = colors or ColorSequence.new{
+                ColorSequenceKeypoint.new(0, Color3.fromRGB(25, 25, 35)),
+                ColorSequenceKeypoint.new(1, Color3.fromRGB(15, 15, 25))
 	}
 	if transparency then
 		gradient.Transparency = transparency
 	end
 	gradient.Rotation = 45
-	gradient.Parent = parent
-	return gradient
+        gradient.Parent = parent
+        return gradient
+end
+
+local function styleNinjaCloseButton(button)
+        if not button then
+                return
+        end
+
+        button.Text = "X"
+        button.Font = Enum.Font.GothamBold
+        button.TextScaled = true
+        button.TextColor3 = Color3.fromRGB(255, 245, 245)
+        button.TextStrokeTransparency = 0.6
+        button.BackgroundColor3 = Color3.fromRGB(28, 28, 36)
+        button.BackgroundTransparency = 0.05
+        button.AutoButtonColor = true
+        button.BorderSizePixel = 0
+
+        for _, child in ipairs(button:GetChildren()) do
+                if child:IsA("UICorner") or child:IsA("UIStroke") then
+                        child:Destroy()
+                end
+        end
+
+        local corner = Instance.new("UICorner")
+        corner.CornerRadius = UDim.new(1, 0)
+        corner.Parent = button
+
+        local stroke = Instance.new("UIStroke")
+        stroke.Color = Color3.fromRGB(220, 70, 70)
+        stroke.Thickness = 2
+        stroke.Transparency = 0.1
+        stroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+        stroke.Parent = button
 end
 
 -- Build the ninja marketplace interface
 function NinjaMarketplaceUI.init(config, shop, bootUI, defaultTab)
-	local root = bootUI and bootUI.root
-	if not root then return end
+        local root = bootUI and bootUI.root
+        if not root then return end
 
 	-- Main marketplace frame
 	frame = Instance.new("Frame")
@@ -146,28 +179,20 @@ function NinjaMarketplaceUI.init(config, shop, bootUI, defaultTab)
 	subtitle.Parent = header
 
 	-- Close button
-	local closeBtn = Instance.new("TextButton")
-	closeBtn.Name = "MarketplaceClose"
-	closeBtn.Size = UDim2.new(0, 45, 0, 45)
-	closeBtn.AnchorPoint = Vector2.new(1, 0)
-	closeBtn.Position = UDim2.new(1, -10, 0, 7.5)
-	closeBtn.Text = "✕"
-	closeBtn.Font = Enum.Font.GothamBold
-	closeBtn.TextScaled = true
-	closeBtn.TextColor3 = Color3.fromRGB(255, 150, 150)
-	closeBtn.BackgroundColor3 = Color3.fromRGB(80, 25, 25)
-	closeBtn.BackgroundTransparency = 0.1
-	closeBtn.BorderSizePixel = 0
+        local closeBtn = Instance.new("TextButton")
+        closeBtn.Name = "MarketplaceClose"
+        closeBtn.Size = UDim2.new(0, 45, 0, 45)
+        closeBtn.AnchorPoint = Vector2.new(1, 0)
+        closeBtn.Position = UDim2.new(1, -10, 0, 7.5)
         closeBtn.ZIndex = BASE_Z_INDEX + 4
-	closeBtn.AutoButtonColor = true
-	closeBtn.Parent = header
-	createCorner(closeBtn, 22.5)
-	createStroke(closeBtn, 2, Color3.fromRGB(120, 40, 40))
+        closeBtn.AutoButtonColor = true
+        closeBtn.Parent = header
+        styleNinjaCloseButton(closeBtn)
 
-	-- Tab bar
-	local tabBar = Instance.new("Frame")
-	tabBar.Name = "TabBar"
-	tabBar.Size = UDim2.new(1, -20, 0, 45)
+        -- Tab bar
+        local tabBar = Instance.new("Frame")
+        tabBar.Name = "TabBar"
+        tabBar.Size = UDim2.new(1, -20, 0, 45)
 	tabBar.Position = UDim2.new(0, 10, 0, 70)
 	tabBar.BackgroundColor3 = Color3.fromRGB(20, 20, 30)
 	tabBar.BackgroundTransparency = 0.3

--- a/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
@@ -16,17 +16,50 @@ local function createCorner(parent, radius)
 end
 
 local function createStroke(parent, thickness, color)
-	local stroke = Instance.new("UIStroke")
-	stroke.Thickness = thickness or 1
-	stroke.Color = color or Color3.fromRGB(100, 100, 100)
-	stroke.Parent = parent
-	return stroke
+        local stroke = Instance.new("UIStroke")
+        stroke.Thickness = thickness or 1
+        stroke.Color = color or Color3.fromRGB(100, 100, 100)
+        stroke.Parent = parent
+        return stroke
+end
+
+local function styleNinjaCloseButton(button)
+        if not button then
+                return
+        end
+
+        button.Text = "X"
+        button.Font = Enum.Font.GothamBold
+        button.TextScaled = true
+        button.TextColor3 = Color3.fromRGB(255, 245, 245)
+        button.TextStrokeTransparency = 0.6
+        button.BackgroundColor3 = Color3.fromRGB(28, 28, 36)
+        button.BackgroundTransparency = 0.05
+        button.AutoButtonColor = true
+        button.BorderSizePixel = 0
+
+        for _, child in ipairs(button:GetChildren()) do
+                if child:IsA("UICorner") or child:IsA("UIStroke") then
+                        child:Destroy()
+                end
+        end
+
+        local corner = Instance.new("UICorner")
+        corner.CornerRadius = UDim.new(1, 0)
+        corner.Parent = button
+
+        local stroke = Instance.new("UIStroke")
+        stroke.Color = Color3.fromRGB(220, 70, 70)
+        stroke.Thickness = 2
+        stroke.Transparency = 0.1
+        stroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+        stroke.Parent = button
 end
 
 function NinjaPouchUI.init(parent, baseY)
-	local self = {}
-	self.data = {gold = 0, shurikens = 0, kunai = 0, scrolls = 0}
-	self.currentTab = "Tools"
+        local self = {}
+        self.data = {gold = 0, shurikens = 0, kunai = 0, scrolls = 0}
+        self.currentTab = "Tools"
 
 	-- Main pouch container
 	local pouch = Instance.new("Frame")
@@ -73,24 +106,17 @@ function NinjaPouchUI.init(parent, baseY)
 	title.Parent = pouch
 
 	-- Close button
-	local closeButton = Instance.new("TextButton")
-	closeButton.Name = "PouchCloseButton"
-	closeButton.Size = UDim2.new(0, 30, 0, 30)
-	closeButton.AnchorPoint = Vector2.new(1, 0)
-	closeButton.Position = UDim2.new(1, -8, 0, 8)
-	closeButton.Text = "✕"
-	closeButton.Font = Enum.Font.GothamBold
-	closeButton.TextScaled = true
-	closeButton.TextColor3 = Color3.fromRGB(255, 100, 100)
-	closeButton.BackgroundColor3 = Color3.fromRGB(40, 15, 15)
-	closeButton.BackgroundTransparency = 0.2
-	closeButton.BorderSizePixel = 0
-	closeButton.Parent = pouch
-	createCorner(closeButton, 15)
+        local closeButton = Instance.new("TextButton")
+        closeButton.Name = "PouchCloseButton"
+        closeButton.Size = UDim2.new(0, 30, 0, 30)
+        closeButton.AnchorPoint = Vector2.new(1, 0)
+        closeButton.Position = UDim2.new(1, -8, 0, 8)
+        closeButton.Parent = pouch
+        styleNinjaCloseButton(closeButton)
 
-	-- Stealth meter
-	local stealthFrame = Instance.new("Frame")
-	stealthFrame.Size = UDim2.new(1, -30, 0, 12)
+        -- Stealth meter
+        local stealthFrame = Instance.new("Frame")
+        stealthFrame.Size = UDim2.new(1, -30, 0, 12)
 	stealthFrame.Position = UDim2.new(0, 15, 0, 60)
 	stealthFrame.BackgroundColor3 = Color3.fromRGB(30, 30, 35)
 	stealthFrame.BorderSizePixel = 0

--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -20,24 +20,57 @@ local function createStroke(parent, thickness, color)
 end
 
 local function createGlow(parent, size, transparency)
-	local glow = Instance.new("ImageLabel")
-	glow.Name = "Glow"
-	glow.Size = UDim2.new(1, size or 20, 1, size or 20)
-	glow.Position = UDim2.new(0, -(size or 20) / 2, 0, -(size or 20) / 2)
+        local glow = Instance.new("ImageLabel")
+        glow.Name = "Glow"
+        glow.Size = UDim2.new(1, size or 20, 1, size or 20)
+        glow.Position = UDim2.new(0, -(size or 20) / 2, 0, -(size or 20) / 2)
 	glow.BackgroundTransparency = 1
 	glow.Image = "rbxasset://textures/ui/GuiImagePlaceholder.png"
 	glow.ImageColor3 = Color3.fromRGB(100, 50, 200)
 	glow.ImageTransparency = transparency or 0.85
 	glow.ZIndex = parent.ZIndex - 1
-	glow.Parent = parent
-	return glow
+        glow.Parent = parent
+        return glow
+end
+
+local function styleNinjaCloseButton(button)
+        if not button then
+                return
+        end
+
+        button.Text = "X"
+        button.Font = Enum.Font.GothamBold
+        button.TextScaled = true
+        button.TextColor3 = Color3.fromRGB(255, 245, 245)
+        button.TextStrokeTransparency = 0.6
+        button.BackgroundColor3 = Color3.fromRGB(28, 28, 36)
+        button.BackgroundTransparency = 0.05
+        button.AutoButtonColor = true
+        button.BorderSizePixel = 0
+
+        for _, child in ipairs(button:GetChildren()) do
+                if child:IsA("UICorner") or child:IsA("UIStroke") then
+                        child:Destroy()
+                end
+        end
+
+        local corner = Instance.new("UICorner")
+        corner.CornerRadius = UDim.new(1, 0)
+        corner.Parent = button
+
+        local stroke = Instance.new("UIStroke")
+        stroke.Color = Color3.fromRGB(220, 70, 70)
+        stroke.Thickness = 2
+        stroke.Transparency = 0.1
+        stroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+        stroke.Parent = button
 end
 
 function NinjaQuestUI.init(parent, baseY)
-	local questRoot = Instance.new("Frame")
-	questRoot.Name = "NinjaQuestUIRoot"
-	questRoot.Size = UDim2.fromScale(1, 1)
-	questRoot.BackgroundTransparency = 1
+        local questRoot = Instance.new("Frame")
+        questRoot.Name = "NinjaQuestUIRoot"
+        questRoot.Size = UDim2.fromScale(1, 1)
+        questRoot.BackgroundTransparency = 1
 	questRoot.ZIndex = 5
 	questRoot.Parent = parent
 
@@ -75,26 +108,18 @@ function NinjaQuestUI.init(parent, baseY)
 	headerTitle.ZIndex = 7
 	headerTitle.Parent = previewHeader
 
-	local closeButton = Instance.new("TextButton")
-	closeButton.Name = "QuestCloseButton"
-	closeButton.Size = UDim2.new(0, 32, 0, 32)
-	closeButton.AnchorPoint = Vector2.new(1, 0)
-	closeButton.Position = UDim2.new(1, -20, 0, 16)
-	closeButton.BackgroundColor3 = Color3.fromRGB(120, 40, 40)
-	closeButton.BackgroundTransparency = 0
-	closeButton.TextColor3 = Color3.new(1, 1, 1)
-	closeButton.Font = Enum.Font.GothamBold
-	closeButton.TextScaled = true
-	closeButton.Text = "X"
-	closeButton.AutoButtonColor = true
-	closeButton.ZIndex = 8
-	closeButton.BorderSizePixel = 0
-	closeButton.Parent = previewHeader
-	createCorner(closeButton, 10)
+        local closeButton = Instance.new("TextButton")
+        closeButton.Name = "QuestCloseButton"
+        closeButton.Size = UDim2.new(0, 32, 0, 32)
+        closeButton.AnchorPoint = Vector2.new(1, 0)
+        closeButton.Position = UDim2.new(1, -20, 0, 16)
+        closeButton.ZIndex = 8
+        closeButton.Parent = previewHeader
+        styleNinjaCloseButton(closeButton)
 
-	local emoteContainer = Instance.new("ScrollingFrame")
-	emoteContainer.Name = "EmoteButtonRow"
-	emoteContainer.Size = UDim2.new(1, -20, 0, 46)
+        local emoteContainer = Instance.new("ScrollingFrame")
+        emoteContainer.Name = "EmoteButtonRow"
+        emoteContainer.Size = UDim2.new(1, -20, 0, 46)
 	emoteContainer.Position = UDim2.new(0, 10, 0, 55)
 	emoteContainer.BackgroundTransparency = 1
 	emoteContainer.ZIndex = 6

--- a/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
@@ -72,6 +72,39 @@ local function track(self, conn)
         return conn
 end
 
+local function styleNinjaCloseButton(button)
+        if not button then
+                return
+        end
+
+        button.Text = "X"
+        button.Font = Enum.Font.GothamBold
+        button.TextScaled = true
+        button.TextColor3 = Color3.fromRGB(255, 245, 245)
+        button.TextStrokeTransparency = 0.6
+        button.BackgroundColor3 = Color3.fromRGB(28, 28, 36)
+        button.BackgroundTransparency = 0.05
+        button.AutoButtonColor = true
+        button.BorderSizePixel = 0
+
+        for _, child in ipairs(button:GetChildren()) do
+                if child:IsA("UICorner") or child:IsA("UIStroke") then
+                        child:Destroy()
+                end
+        end
+
+        local corner = Instance.new("UICorner")
+        corner.CornerRadius = UDim.new(1, 0)
+        corner.Parent = button
+
+        local stroke = Instance.new("UIStroke")
+        stroke.Color = Color3.fromRGB(220, 70, 70)
+        stroke.Thickness = 2
+        stroke.Transparency = 0.1
+        stroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+        stroke.Parent = button
+end
+
 function TeleportUI:setVisible(visible)
         if self._destroyed then return end
         if self.root then
@@ -172,19 +205,10 @@ function TeleportUI.init(parent, baseY, dependencies)
         teleportCloseButton.Size = UDim2.new(0, 32, 0, 32)
         teleportCloseButton.AnchorPoint = Vector2.new(1, 0)
         teleportCloseButton.Position = UDim2.new(1, -20, 0, 16)
-        teleportCloseButton.BackgroundColor3 = Color3.fromRGB(120, 40, 40)
-        teleportCloseButton.TextColor3 = Color3.new(1, 1, 1)
-        teleportCloseButton.Text = "X"
-        teleportCloseButton.Font = Enum.Font.GothamBold
-        teleportCloseButton.TextScaled = true
-        teleportCloseButton.AutoButtonColor = true
         teleportCloseButton.Visible = false
         teleportCloseButton.ZIndex = BASE_Z_INDEX + 5
         teleportCloseButton.Parent = teleportContainer
-
-        local teleportCloseCorner = Instance.new("UICorner")
-        teleportCloseCorner.CornerRadius = UDim.new(0, 10)
-        teleportCloseCorner.Parent = teleportCloseButton
+        styleNinjaCloseButton(teleportCloseButton)
 
         local teleportContent = Instance.new("Frame")
         teleportContent.Name = "TeleportContent"


### PR DESCRIPTION
## Summary
- restyle the close buttons in the teleport, quest, pouch, and marketplace interfaces with a consistent ninja-themed circular design

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d89da7331083329d22331cd1da42b7