### PR TITLE
Keep loadout menu buttons visible after teleport

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -571,6 +571,13 @@ function WorldHUD:handlePostTeleport()
         self.menuAutoExpand = true
         self:setMenuExpanded(true)
 
+        -- The call to closeAllInterfaces hides the quick-access buttons that live
+        -- inside the loadout menu. Explicitly re-enable them here so they remain
+        -- available after a teleport (such as when entering the dojo).
+        self:setQuestVisible(true)
+        self:setBackpackVisible(true)
+        self:setTeleportVisible(true)
+
         if self.loadout then
                 self.loadout.Visible = true
         end


### PR DESCRIPTION
## Summary
- restore quest, backpack, and teleport buttons after `closeAllInterfaces` when the player finishes teleporting
- ensure the dojo teleport keeps the menu expanded so players can access loadout actions immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b6cb13248332974dffcf9eff0f0a