### PR TITLE
Ensure dojo teleports keep loadout menu accessible

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -743,6 +743,16 @@ if enterRealmButton then
 
             DojoClient.hide()
             restoreUIBlur()
+            local hudAfterTeleport = BootUI.hud
+            if hudAfterTeleport and hudAfterTeleport.handlePostTeleport then
+                -- Re-open the loadout menu shortly after spawning so the quick-access
+                -- buttons (quests, pouch, teleports, shop) remain available in the dojo.
+                task.defer(function()
+                    if hudAfterTeleport and hudAfterTeleport.handlePostTeleport then
+                        hudAfterTeleport:handlePostTeleport()
+                    end
+                end)
+            end
             local fadeTween = TweenService:Create(fade, TweenInfo.new(0.35), {BackgroundTransparency = 1})
             fadeTween.Completed:Connect(function(playbackState)
                 if playbackState == Enum.PlaybackState.Completed then


### PR DESCRIPTION
## Summary
- re-run the HUD post-teleport handler after entering the dojo so the loadout menu and its quick-access buttons remain available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8b8a6343c8332883b3f7595e4e238