### PR TITLE
Hide loadout header in world state

### DIFF
--- a/ReplicatedStorage/ClientModules/TeleportClient.lua
+++ b/ReplicatedStorage/ClientModules/TeleportClient.lua
@@ -118,7 +118,12 @@ function TeleportClient.bindZoneButtons(gui, callbacks)
                 if button then
                         button.Activated:Connect(function()
                                 if onTeleport then
-                                        onTeleport()
+                                        onTeleport({
+                                                source = "Zone",
+                                                name = name,
+                                                island = zoneInfo[1],
+                                                location = zoneInfo[2],
+                                        })
                                 end
                                 teleportToIsland(unpack(zoneInfo))
                         end)
@@ -361,7 +366,11 @@ function TeleportClient.bindWorldButtons(gui, callbacks)
                local placeId = TeleportClient.worldSpawnIds[selectedRealm]
                if placeId and placeId > 0 then
                        if onTeleport then
-                               onTeleport()
+                               onTeleport({
+                                       source = "Realm",
+                                       realm = selectedRealm,
+                                       placeId = placeId,
+                               })
                        end
                        teleportToPlace(placeId)
                else


### PR DESCRIPTION
## Summary
- propagate teleport context so the HUD knows when the player moves into the world
- add world-mode handling that hides the loadout topper and back button while still keeping quick-access panels visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8ba5d75988332b5e846b275e87ecd