### PR TITLE
Handle HUD post-teleport when entering realms

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -776,6 +776,13 @@ if enterRealmButton then
             TweenService:Create(fade, TweenInfo.new(0.25), {BackgroundTransparency = 0}):Play()
             task.wait(0.28)
             local _, chosenSlot = Cosmetics.getSelectedPersona()
+            local hudBeforeTeleport = BootUI.hud
+            if hudBeforeTeleport and hudBeforeTeleport.handlePostTeleport then
+                hudBeforeTeleport:handlePostTeleport({
+                    source = "Realm",
+                    realm = realmName,
+                })
+            end
             DojoClient.hide()
             local ok, err = pcall(function()
                 TeleportService:Teleport(placeId, player, {slot = chosenSlot})


### PR DESCRIPTION
## Summary
- ensure the HUD is notified before teleporting to external realms
- pass the realm context to handlePostTeleport so the HUD can switch modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c24295188332b43db8c7919b6eaf