### PR TITLE
Hide other interfaces when teleport is open

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -425,6 +425,14 @@ end
 
 function WorldHUD:setTeleportVisible(visible)
         setInterfaceVisible(self.teleportUI, visible)
+
+        if visible then
+                setInterfaceVisible(self.quest, false)
+                setInterfaceVisible(self.backpack, false)
+                if self.shopFrame then
+                        self.shopFrame.Visible = false
+                end
+        end
 end
 
 function WorldHUD:closeAllInterfaces()


### PR DESCRIPTION
## Summary
- ensure the teleport UI forces the quest, pouch, and shop interfaces closed when it is displayed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d97868888332a753c5bffca4004e