### PR TITLE
Hide loadout UI during teleports and add persona return button

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -704,6 +704,14 @@ if backButton then
     end)
 end
 
+local personaButton = hud and hud.getPersonaButton and hud:getPersonaButton()
+if personaButton then
+    personaButton.MouseButton1Click:Connect(function()
+        applyStartCam()
+        Cosmetics.showDojoPicker()
+    end)
+end
+
 local enterRealmButton = hud and hud.enterRealmButton
 if enterRealmButton then
     enterRealmButton.MouseButton1Click:Connect(function()


### PR DESCRIPTION
## Summary
- add a Persona button to the world HUD that appears after using the teleport hub and returns players to persona selection
- hide the loadout header, back button, and related UI when a teleport is triggered and keep visibility states in sync during dissolves

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8de937d7c833286f5e409bde85a11