### PR TITLE
Fix missing end in BootUI persona data handling

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -295,6 +295,7 @@ function BootUI.applyFetchedData(data)
         end
 
         Cosmetics.showDojoPicker()
+    end
 end
 
 function BootUI.getSelectedRealm()


### PR DESCRIPTION
## Summary
- restore the missing conditional terminator inside `BootUI.applyFetchedData`
- ensure persona data processing closes cleanly before returning to other helpers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8e3ac9c4c8332a5cb5def19a12523