### PR TITLE
Disable Roblox player list

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
+++ b/StarterPlayer/StarterPlayerScripts/MainLocalScript.lua
@@ -1,11 +1,19 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local StarterGui = game:GetService("StarterGui")
 
 local ActionUI = require(ReplicatedStorage.ClientModules.UI.ActionUI)
 
 local player = Players.LocalPlayer
 
 local function initializeActionUI()
+    local coreGuiSuccess, coreGuiErr = pcall(function()
+        StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.PlayerList, false)
+    end)
+    if not coreGuiSuccess then
+        warn("Failed to disable player list:", coreGuiErr)
+    end
+
     task.defer(function()
         local success, err = pcall(ActionUI.init)
         if not success then


### PR DESCRIPTION
## Summary
- require StarterGui so the script can manage core GUI visibility
- disable the default player list each time the action UI initializes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8e6ecceb08332b84ea68a04d17140