### PR TITLE
Fix cosmetics confirmation overlay error

### DIFF
--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -315,14 +315,16 @@ end
 -- ═══════════════════════════════════════════════════════════════
 
 local function showNinjaConfirmation(message, onConfirm)
-	local overlay = Instance.new("Frame")
-	overlay.Size = UDim2.fromScale(1, 1)
-	overlay.BackgroundColor3 = Color3.new(0, 0, 0)
-	overlay.BackgroundTransparency = 0.3
-	overlay.ZIndex = 300
-	overlay.Active = true
-	overlay.Modal = true
-	overlay.Parent = rootUI
+        local overlay = Instance.new("TextButton")
+        overlay.Size = UDim2.fromScale(1, 1)
+        overlay.BackgroundColor3 = Color3.new(0, 0, 0)
+        overlay.BackgroundTransparency = 0.3
+        overlay.ZIndex = 300
+        overlay.Active = true
+        overlay.Modal = true
+        overlay.AutoButtonColor = false
+        overlay.Text = ""
+        overlay.Parent = rootUI
 
 	local dialog = createStyledFrame(overlay, 
 		UDim2.fromScale(0.35, 0.3), 


### PR DESCRIPTION
## Summary
- replace the cosmetics confirmation overlay Frame with a TextButton so the Modal property can be applied without runtime errors
- keep the overlay appearance while disabling button visuals to preserve the modal confirmation behavior

## Testing
- not run (N/A)

------
https://chatgpt.com/codex/tasks/task_e_68d8f5f2b5c483329d8b8c040d4f34c2