### PR TITLE
Ensure persona deletions update UI immediately

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -370,6 +370,21 @@ if not cosmeticsInterface.getStarterBackpack then
     end
 end
 
+if not cosmeticsInterface.updatePersonaData then
+    cosmeticsInterface.updatePersonaData = function(newData)
+        if typeof(newData) ~= "table" then
+            BootUI.personaData = nil
+            BootUI.config = BootUI.config or {}
+            BootUI.config.personaData = nil
+            return
+        end
+
+        BootUI.config = BootUI.config or {}
+        BootUI.config.personaData = newData
+        BootUI.personaData = newData
+    end
+end
+
 BootUI.cosmeticsInterface = cosmeticsInterface
 
 BootUI.populateBackpackUI(config.inventory)

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -103,10 +103,10 @@ end
 
 -- Enhanced persona data sanitizer
 local function sanitizePersonaData(data)
-	local result = {}
-	local slots = nil
+        local result = {}
+        local slots = nil
 
-	-- Extract slots data
+        -- Extract slots data
 	if typeof(data) == "table" then
 		for key, value in pairs(data) do
 			if key == "slots" and typeof(value) == "table" then
@@ -148,8 +148,28 @@ local function sanitizePersonaData(data)
 		slotCount = DEFAULT_SLOT_COUNT
 	end
 
-	result.slotCount = slotCount
-	return result
+        result.slotCount = slotCount
+        return result
+end
+
+local function clonePersonaData(data)
+        if typeof(data) ~= "table" then
+                return data
+        end
+
+        local cloned = table.clone(data)
+
+        if typeof(data.slots) == "table" then
+                cloned.slots = table.clone(data.slots)
+
+                for index, slot in pairs(cloned.slots) do
+                        if typeof(slot) == "table" then
+                                cloned.slots[index] = table.clone(slot)
+                        end
+                end
+        end
+
+        return cloned
 end
 
 -- ═══════════════════════════════════════════════════════════════
@@ -549,10 +569,11 @@ local function updateSlotDisplays()
 end
 
 local function refreshSlotData(newData)
-	personaCache = sanitizePersonaData(newData)
-	ensureValidSelection()
-	updateSlotDisplays()
-	updateSelectedPersonaLabel()
+        personaCache = sanitizePersonaData(newData)
+        ensureValidSelection()
+        updateSlotDisplays()
+        updateSelectedPersonaLabel()
+        callUICallback("updatePersonaData", clonePersonaData(personaCache))
 end
 
 -- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add a cosmetics interface callback so BootUI can update its cached persona data when slots change
- notify the UI bridge whenever persona data is refreshed to immediately reflect deletions without rejoining

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8f7eacd90833297074862b7556357