### PR TITLE
Integrate ability status into Ninja Quest UI

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
+++ b/ReplicatedStorage/ClientModules/UI/WorldHUD.lua
@@ -858,8 +858,18 @@ function WorldHUD.new(config, dependencies)
 	self.teleportCloseButton = teleportCloseButton
 	self.enterRealmButton = teleportUI and teleportUI.enterRealmButton or nil
 
-	local quest = NinjaQuestUI.init(loadout, baseY)
-	self.quest = quest
+        local quest = NinjaQuestUI.init(loadout, baseY, {
+                openAbilityShop = function(abilityName)
+                        if self:showShop("Abilities") then
+                                if abilityName and NinjaMarketplaceUI.focusAbility then
+                                        NinjaMarketplaceUI.focusAbility(abilityName)
+                                elseif NinjaMarketplaceUI.setTab then
+                                        NinjaMarketplaceUI.setTab("Abilities")
+                                end
+                        end
+                end,
+        })
+        self.quest = quest
 
 	local backpack = NinjaPouchUI.init(loadout, baseY)
 	self.backpack = backpack
@@ -1209,19 +1219,20 @@ function WorldHUD:setBackButtonEnabled(enabled)
 	self:updateLoadoutHeaderVisibility()
 end
 
-function WorldHUD:toggleShop(defaultTab)
-	if not self.shop then
-		warn("WorldHUD: shop instance missing")
-		return
-	end
-	if not self.shopFrame or not self.shopFrame.Parent then
-		local fakeBoot = {root = self.root}
-		self.shopFrame = NinjaMarketplaceUI.init(self.config, self.shop, fakeBoot, defaultTab)
-	else
-		self.shopFrame.Visible = not self.shopFrame.Visible
-	end
-        if self.shopFrame and self.shopFrame.Visible and defaultTab and NinjaMarketplaceUI.setTab then
-                NinjaMarketplaceUI.setTab(defaultTab)
+function WorldHUD:showShop(defaultTab)
+        if not self.shop then
+                warn("WorldHUD: shop instance missing")
+                return false
+        end
+
+        local fakeBoot = {root = self.root}
+        if not self.shopFrame or not self.shopFrame.Parent then
+                self.shopFrame = NinjaMarketplaceUI.init(self.config, self.shop, fakeBoot, defaultTab)
+        else
+                self.shopFrame.Visible = true
+                if defaultTab and NinjaMarketplaceUI.setTab then
+                        NinjaMarketplaceUI.setTab(defaultTab)
+                end
         end
 
         if self.shopFrame and self.shopFrame.Visible then
@@ -1230,6 +1241,19 @@ function WorldHUD:toggleShop(defaultTab)
         end
 
         return self.shopFrame and self.shopFrame.Visible
+end
+
+function WorldHUD:toggleShop(defaultTab)
+        if not self.shop then
+                warn("WorldHUD: shop instance missing")
+                return
+        end
+        if self.shopFrame and self.shopFrame.Visible then
+                self.shopFrame.Visible = false
+                return false
+        end
+
+        return self:showShop(defaultTab)
 end
 
 function WorldHUD:setBackpackData(data)


### PR DESCRIPTION
## Summary
- add an ability status row to the quest UI that reflects unlock state and deep-links to the marketplace
- teach the world HUD how to ensure the marketplace opens on the abilities tab when requested
- add a marketplace helper that focuses and highlights a specific ability card when opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b76ac2cc83329453b2802c43aa1d