### PR TITLE
Make quest ability row horizontally scrollable

### DIFF
--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -203,12 +203,17 @@ function NinjaQuestUI.init(parent, baseY, options)
         abilityHeader.ZIndex = 7
         abilityHeader.Parent = abilityContainer
 
-        local abilityRow = Instance.new("Frame")
+        local abilityRow = Instance.new("ScrollingFrame")
         abilityRow.Name = "AbilityRow"
         abilityRow.Size = UDim2.new(1, 0, 0, 32)
         abilityRow.Position = UDim2.new(0, 0, 0, 24)
         abilityRow.BackgroundTransparency = 1
         abilityRow.ZIndex = 7
+        abilityRow.ScrollBarThickness = 4
+        abilityRow.ScrollingDirection = Enum.ScrollingDirection.X
+        abilityRow.AutomaticCanvasSize = Enum.AutomaticSize.X
+        abilityRow.CanvasSize = UDim2.new(0, 0, 0, 32)
+        abilityRow.ClipsDescendants = true
         abilityRow.Parent = abilityContainer
 
         local abilityLayout = Instance.new("UIListLayout")


### PR DESCRIPTION
## Summary
- update the quest UI ability row to use a horizontal scrolling frame so additional abilities can be accessed like the emote row

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9bac2138c8332a453d0a6afc0c218