### PR TITLE
Add dojo return confirmation prompt

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -630,13 +630,15 @@ function BootUI.start(config)
 	fade.ZIndex = 50
 	fade.Parent = root
 
-	local backButton = hud and hud.backButton
-	if backButton then
-		backButton.MouseButton1Click:Connect(function()
-			applyStartCam()
-			Cosmetics.showDojoPicker()
-		end)
-	end
+        local backButton = hud and hud.backButton
+        if backButton then
+                backButton.MouseButton1Click:Connect(function()
+                        local currentHud = BootUI.hud
+                        if currentHud and currentHud.promptReturnToDojo then
+                                currentHud:promptReturnToDojo()
+                        end
+                end)
+        end
 
 	local personaButton = hud and hud.getPersonaButton and hud:getPersonaButton()
 	if personaButton then


### PR DESCRIPTION
## Summary
- center the HUD back button near the loadout header and wire it through a tracked dojo-return helper
- add a confirmation modal that runs the dojo loading, teleports, and cosmetics reopening sequence
- update BootUI to call the HUD confirmation flow instead of directly toggling cosmetics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2026467483328299c700bb99aeb6