### PR TITLE
Fix BootUI intro blur helpers order

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -647,6 +647,49 @@ function BootUI.start(config)
                 cosmeticsInterface.tweenToEnd = tweenToEnd
         end
 
+        -- Lighting helpers (disable DOF while UI is visible)
+        -- =====================
+        local savedDOF
+        local savedBlurEnabled
+        local function getOrCreateBlur()
+                local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
+                if not blur then
+                        blur = Instance.new("BlurEffect")
+                        blur.Name = "Blur"
+                        blur.Enabled = false
+                        blur.Parent = Lighting
+                end
+                return blur
+        end
+        local function disableUIBlur()
+                if savedDOF or savedBlurEnabled ~= nil then return end
+                savedDOF = {}
+                for _,e in ipairs(Lighting:GetChildren()) do
+                        if e:IsA("DepthOfFieldEffect") then
+                                savedDOF[e] = e.Enabled
+                                e.Enabled = false
+                        end
+                end
+                local blur = getOrCreateBlur()
+                if blur then
+                        savedBlurEnabled = blur.Enabled
+                        blur.Enabled = false
+                end
+        end
+        local function restoreUIBlur()
+                if savedDOF then
+                        for e,was in pairs(savedDOF) do
+                                if e and e.Parent then e.Enabled = was end
+                        end
+                        savedDOF = nil
+                end
+                if savedBlurEnabled ~= nil then
+                        local blur = getOrCreateBlur()
+                        if blur then blur.Enabled = savedBlurEnabled end
+                        savedBlurEnabled = nil
+                end
+        end
+
         local function replayIntroSequence(options)
                 options = options or {}
                 cam = Workspace.CurrentCamera or cam
@@ -670,49 +713,6 @@ function BootUI.start(config)
         end
 
         BootUI.replayIntroSequence = replayIntroSequence
-
-	-- Lighting helpers (disable DOF while UI is visible)
-	-- =====================
-	local savedDOF
-	local savedBlurEnabled
-	local function getOrCreateBlur()
-		local blur = Lighting:FindFirstChild("Blur") or Lighting:FindFirstChildOfClass("BlurEffect")
-		if not blur then
-			blur = Instance.new("BlurEffect")
-			blur.Name = "Blur"
-			blur.Enabled = false
-			blur.Parent = Lighting
-		end
-		return blur
-	end
-	local function disableUIBlur()
-		if savedDOF or savedBlurEnabled ~= nil then return end
-		savedDOF = {}
-		for _,e in ipairs(Lighting:GetChildren()) do
-			if e:IsA("DepthOfFieldEffect") then
-				savedDOF[e] = e.Enabled
-				e.Enabled = false
-			end
-		end
-		local blur = getOrCreateBlur()
-		if blur then
-			savedBlurEnabled = blur.Enabled
-			blur.Enabled = false
-		end
-	end
-	local function restoreUIBlur()
-		if savedDOF then
-			for e,was in pairs(savedDOF) do
-				if e and e.Parent then e.Enabled = was end
-			end
-			savedDOF = nil
-		end
-		if savedBlurEnabled ~= nil then
-			local blur = getOrCreateBlur()
-			if blur then blur.Enabled = savedBlurEnabled end
-			savedBlurEnabled = nil
-		end
-	end
 
         local introController = {
                 freezeCharacter = freezeCharacter,


### PR DESCRIPTION
## Summary
- reorder the UI blur helper definitions so they are initialized before replayIntroSequence uses them
- keep the intro controller wiring unchanged while preventing nil function calls during the intro sequence

## Testing
- not run (Roblox environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da2876c9d4833291427c680bf056a0