### PR TITLE
Replace deprecated GothamSemibold font usage

### DIFF
--- a/ReplicatedStorage/BootModules/AbilityUI.lua
+++ b/ReplicatedStorage/BootModules/AbilityUI.lua
@@ -409,7 +409,7 @@ function AbilityUI:createAbilityEntry(abilityName, info)
     costLabel.Name = "CostLabel"
     costLabel.Size = UDim2.new(1, -150, 1, 0)
     costLabel.BackgroundTransparency = 1
-    costLabel.Font = Enum.Font.GothamSemibold
+    costLabel.Font = Enum.Font.GothamMedium
     costLabel.TextSize = 18
     costLabel.TextXAlignment = Enum.TextXAlignment.Left
     costLabel.TextColor3 = TEXT_COLORS.secondary

--- a/ReplicatedStorage/BootModules/Cosmetics.lua
+++ b/ReplicatedStorage/BootModules/Cosmetics.lua
@@ -265,7 +265,7 @@ local function createNinjaButton(parent, text, size, position, color, onClick)
 	button.Size = size
 	button.Position = position
 	button.Text = text
-	button.Font = Enum.Font.GothamSemibold
+        button.Font = Enum.Font.GothamMedium
 	button.TextScaled = true
 	button.TextColor3 = NINJA_COLORS.TEXT_PRIMARY
 	button.BackgroundColor3 = color or NINJA_COLORS.ACCENT
@@ -338,7 +338,7 @@ local function showNinjaConfirmation(message, onConfirm)
 	title.Position = UDim2.new(0, 10, 0, 10)
 	title.BackgroundTransparency = 1
 	title.Text = "⚠️ Shadow Council Confirmation"
-	title.Font = Enum.Font.GothamSemibold
+        title.Font = Enum.Font.GothamMedium
 	title.TextScaled = true
 	title.TextColor3 = NINJA_COLORS.ACCENT
 	title.ZIndex = 302
@@ -714,7 +714,7 @@ local function createPersonaSlot(parent, slotIndex, size, position, anchorPoint)
 	levelLabel.Position = UDim2.new(0, 5, 0, 5)
 	levelLabel.BackgroundTransparency = 1
 	levelLabel.Text = "⭐ Level 1"
-	levelLabel.Font = Enum.Font.GothamSemibold
+        levelLabel.Font = Enum.Font.GothamMedium
 	levelLabel.TextSize = 12
 	levelLabel.TextColor3 = NINJA_COLORS.ACCENT
 	levelLabel.TextXAlignment = Enum.TextXAlignment.Left

--- a/ReplicatedStorage/ClientModules/UI/NinjaMarketplaceUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaMarketplaceUI.lua
@@ -244,7 +244,7 @@ function NinjaMarketplaceUI.init(config, shop, bootUI, defaultTab)
 		btn.BackgroundColor3 = Color3.fromRGB(35, 35, 45)
 		btn.BackgroundTransparency = 0.2
 		btn.TextColor3 = Color3.fromRGB(200, 200, 220)
-		btn.Font = Enum.Font.GothamSemibold
+                btn.Font = Enum.Font.GothamMedium
 		btn.TextScaled = true
 		btn.BorderSizePixel = 0
                 btn.ZIndex = BASE_Z_INDEX + 2
@@ -346,7 +346,7 @@ function NinjaMarketplaceUI.init(config, shop, bootUI, defaultTab)
 		rarityLabel.BackgroundColor3 = Color3.fromRGB(50, 25, 80)
 		rarityLabel.BackgroundTransparency = 0.3
 		rarityLabel.Text = itemInfo.rarity or "Common"
-		rarityLabel.Font = Enum.Font.GothamSemibold
+                rarityLabel.Font = Enum.Font.GothamMedium
 		rarityLabel.TextScaled = true
 		rarityLabel.TextColor3 = Color3.fromRGB(180, 150, 220)
 		rarityLabel.BorderSizePixel = 0

--- a/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaPouchUI.lua
@@ -166,7 +166,7 @@ function NinjaPouchUI.init(parent, baseY)
 		btn.BackgroundColor3 = Color3.fromRGB(40, 40, 45)
 		btn.BackgroundTransparency = 0.3
 		btn.TextColor3 = Color3.fromRGB(200, 200, 220)
-		btn.Font = Enum.Font.GothamSemibold
+                btn.Font = Enum.Font.GothamMedium
 		btn.TextScaled = true
 		btn.Text = tab.icon .. "\n" .. tab.name
 		btn.BorderSizePixel = 0
@@ -275,7 +275,7 @@ function NinjaPouchUI.init(parent, baseY)
 		nameLabel.Position = UDim2.new(0, 50, 0, 5)
 		nameLabel.BackgroundTransparency = 1
 		nameLabel.TextXAlignment = Enum.TextXAlignment.Left
-		nameLabel.Font = Enum.Font.GothamSemibold
+                nameLabel.Font = Enum.Font.GothamMedium
 		nameLabel.TextScaled = true
 		nameLabel.TextColor3 = Color3.fromRGB(220, 220, 240)
 		nameLabel.Text = item.name

--- a/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/NinjaQuestUI.lua
@@ -148,7 +148,7 @@ function NinjaQuestUI.init(parent, baseY, options)
 		btn.BackgroundColor3 = Color3.fromRGB(40, 40, 50)
 		btn.BackgroundTransparency = 0.2
 		btn.TextColor3 = Color3.fromRGB(200, 200, 220)
-		btn.Font = Enum.Font.GothamSemibold
+                btn.Font = Enum.Font.GothamMedium
 		btn.TextScaled = true
 		btn.AutoButtonColor = true
 		btn.Text = (icon or "⚫") .. " " .. text
@@ -197,7 +197,7 @@ function NinjaQuestUI.init(parent, baseY, options)
         abilityHeader.BackgroundTransparency = 1
         abilityHeader.TextXAlignment = Enum.TextXAlignment.Left
         abilityHeader.Text = "⚡ Abilities"
-        abilityHeader.Font = Enum.Font.GothamSemibold
+        abilityHeader.Font = Enum.Font.GothamMedium
         abilityHeader.TextScaled = true
         abilityHeader.TextColor3 = Color3.fromRGB(200, 200, 220)
         abilityHeader.ZIndex = 7
@@ -429,7 +429,7 @@ function NinjaQuestUI.init(parent, baseY, options)
                 btn.BackgroundTransparency = 0.35
                 btn.Text = string.format("%s %s", def.icon or "⚡", def.label or abilityName)
                 btn.TextColor3 = Color3.fromRGB(140, 140, 160)
-                btn.Font = Enum.Font.GothamSemibold
+                btn.Font = Enum.Font.GothamMedium
                 btn.TextScaled = true
                 btn.AutoButtonColor = false
                 btn.BorderSizePixel = 0

--- a/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
+++ b/ReplicatedStorage/ClientModules/UI/TeleportUI.lua
@@ -53,7 +53,7 @@ local function createRealmButton(parent, info, order)
         btn.Size = UDim2.new(1, 0, 0, 44)
         btn.LayoutOrder = order or 0
         btn.Text = info.name
-        btn.Font = Enum.Font.GothamSemibold
+        btn.Font = Enum.Font.GothamMedium
         btn.TextScaled = true
         btn.BackgroundColor3 = Color3.fromRGB(40, 40, 48)
         btn.TextColor3 = Color3.fromRGB(170, 170, 170)
@@ -251,7 +251,7 @@ function TeleportUI.init(parent, baseY, dependencies)
         localTitle.BackgroundTransparency = 1
         localTitle.Text = "Locations"
         localTitle.TextXAlignment = Enum.TextXAlignment.Left
-        localTitle.Font = Enum.Font.GothamSemibold
+        localTitle.Font = Enum.Font.GothamMedium
         localTitle.TextScaled = true
         localTitle.TextColor3 = Color3.fromRGB(200, 200, 220)
         localTitle.ZIndex = BASE_Z_INDEX + 3
@@ -294,7 +294,7 @@ function TeleportUI.init(parent, baseY, dependencies)
                 button.BackgroundColor3 = Color3.fromRGB(50, 120, 255)
                 button.BackgroundTransparency = 0.2
                 button.TextColor3 = Color3.new(1, 1, 1)
-                button.Font = Enum.Font.GothamSemibold
+                button.Font = Enum.Font.GothamMedium
                 button.TextScaled = true
                 button.AutoButtonColor = true
                 button.Text = info.label
@@ -311,7 +311,7 @@ function TeleportUI.init(parent, baseY, dependencies)
         worldTitle.BackgroundTransparency = 1
         worldTitle.Text = "Realms"
         worldTitle.TextXAlignment = Enum.TextXAlignment.Left
-        worldTitle.Font = Enum.Font.GothamSemibold
+        worldTitle.Font = Enum.Font.GothamMedium
         worldTitle.TextScaled = true
         worldTitle.TextColor3 = Color3.fromRGB(200, 200, 220)
         worldTitle.ZIndex = BASE_Z_INDEX + 3


### PR DESCRIPTION
## Summary
- replace deprecated `Enum.Font.GothamSemibold` references with `Enum.Font.GothamMedium` in ability, cosmetics, pouch, quest, marketplace, and teleport UI scripts to align with current Roblox font support

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68db528a8f388332a2d75dbbf402ffd6