### PR TITLE
Validate datastore payloads before loading

### DIFF
--- a/ServerScriptService/DataSavingScript.lua
+++ b/ServerScriptService/DataSavingScript.lua
@@ -204,7 +204,18 @@ local function loadPlayerData(player)
         return DataStore:GetAsync(key)
     end)
     if success then
-        data = data or deepCopy(DEFAULT_DATA)
+        if data ~= nil and typeof(data) ~= "table" then
+            warn(string.format(
+                "Invalid data for %s from datastore (type %s): %s",
+                player.Name,
+                typeof(data),
+                tostring(data)
+            ))
+            data = deepCopy(DEFAULT_DATA)
+        else
+            data = typeof(data) == "table" and data or deepCopy(DEFAULT_DATA)
+        end
+
         fillMissing(data, DEFAULT_DATA)
         data.elements = sanitizeElements(data.elements)
         data.slots = typeof(data.slots) == "table" and data.slots or {}


### PR DESCRIPTION
## Summary
- ensure player save data loaded from DataStore is a table before using it
- warn and reset to default data when invalid payloads are encountered to keep slot handling safe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db61220314833293f6b7508a5ca2e0