### PR TITLE
Add double jump ability and enhance jump logic

### DIFF
--- a/ReplicatedStorage/ClientModules/AbilityMetadata.lua
+++ b/ReplicatedStorage/ClientModules/AbilityMetadata.lua
@@ -1,4 +1,5 @@
 local AbilityMetadata = {
+    DoubleJump = {cost = 75, prerequisites = {}},
     Toss = {cost = 50, prerequisites = {}},
     Star = {cost = 100, prerequisites = {"Toss"}},
     Rain = {cost = 200, prerequisites = {"Star"}},


### PR DESCRIPTION
## Summary
- add a Double Jump ability button, metadata entry, and keybind mapping
- update jump handling to consume ability-provided charges and apply double jump boosts
- provide effect feedback when Double Jump is activated and reset temporary attributes safely

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db64d8391c8332a694ac6bde85365a