### PR TITLE
Move water orb collection to client

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/WaterOrbCollector.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/WaterOrbCollector.client.lua
@@ -1,0 +1,50 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+
+local BootUI = require(ReplicatedStorage:WaitForChild("BootModules"):WaitForChild("BootUI"))
+
+local player = Players.LocalPlayer
+local orb = Workspace:WaitForChild("HiddenDojo"):WaitForChild("Orbs"):WaitForChild("WaterCoin")
+local claimed = false
+
+local function isPlayerCharacterPart(part)
+        if not player then
+                return false
+        end
+
+        local character = player.Character
+        if not character then
+                return false
+        end
+
+        if not part or not part:IsDescendantOf(character) then
+                return false
+        end
+
+        local humanoid = character:FindFirstChildOfClass("Humanoid")
+        return humanoid ~= nil
+end
+
+orb.Touched:Connect(function(hit)
+        if claimed then
+                return
+        end
+
+        if not isPlayerCharacterPart(hit) then
+                return
+        end
+
+        local currencyService = BootUI.currencyService
+        if not currencyService or not currencyService.AddOrb then
+                warn("WaterOrbCollector: Currency service unavailable")
+                return
+        end
+
+        claimed = true
+        currencyService:AddOrb("Water")
+
+        if orb.Parent then
+                orb:Destroy()
+        end
+end)

--- a/Workspace/HiddenDojo/Orbs/WaterCoin/CollectScript.server.lua
+++ b/Workspace/HiddenDojo/Orbs/WaterCoin/CollectScript.server.lua
@@ -1,0 +1,3 @@
+-- Legacy water orb collection script disabled.
+-- Orb collection is now handled by StarterPlayerScripts/WaterOrbCollector.client.lua.
+return


### PR DESCRIPTION
## Summary
- add a WaterOrbCollector LocalScript that awards the water orb when the local player touches the WaterCoin
- disable the legacy WaterCoin CollectScript on the server so it no longer requires client-only modules

## Testing
- not run (project contains Roblox scripts)


------
https://chatgpt.com/codex/tasks/task_e_68df77ece0bc833291082e63ac584f41