### PR TITLE
Restore replay intro sequence usage

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -844,33 +844,9 @@ function BootUI.start(config)
 
         BootUI.replayIntroSequence = replayIntroSequence
 
-        local function playIntroSequence(options)
-                options = options or {}
-                replayIntroSequence(options)
-                print("BootUI: Playing intro sequence")
-
-                if options.tweenToEnd ~= false then
-                        local tweenDelay = options.tweenDelay
-                        if tweenDelay == nil then
-                                tweenDelay = options.holdTime or 0.3
-                        end
-
-                        if tweenDelay and tweenDelay > 0 then
-                                task.delay(tweenDelay, function()
-                                        tweenToEnd()
-                                end)
-                        else
-                                tweenToEnd()
-                        end
-                end
-        end
-
-        BootUI.playIntroSequence = playIntroSequence
-
         local introController = {
                 freezeCharacter = freezeCharacter,
                 replayIntroSequence = replayIntroSequence,
-                playIntroSequence = playIntroSequence,
                 disableUIBlur = disableUIBlur,
                 restoreUIBlur = restoreUIBlur,
         }
@@ -1030,7 +1006,7 @@ function BootUI.start(config)
 	-- =====================
 	-- FLOW
 	-- =====================
-        BootUI.playIntroSequence({
+        BootUI.replayIntroSequence({
                 holdTime = 0.3,
                 personaData = config.personaData,
         })


### PR DESCRIPTION
## Summary
- remove the unused playIntroSequence wrapper and revert to replayIntroSequence for the boot flow
- drop the intro controller export for playIntroSequence so callers stick to the working replayIntroSequence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1fd83c14083329e4fb065cb44065a