### PR TITLE
Allow server spawn logic to find intro cameras recursively

### DIFF
--- a/ServerScriptService/Init.server.lua
+++ b/ServerScriptService/Init.server.lua
@@ -51,7 +51,7 @@ local function findSpawn()
 end
 
 local function getEndFacing()
-	local cams = Workspace:FindFirstChild("Cameras")
+        local cams = Workspace:FindFirstChild("Cameras", true)
 	local endPos = cams and cams:FindFirstChild("endPos")
 	if endPos and endPos:IsA("BasePart") then
 		-- Camera looks along endPos.LookVector; to face the camera, use the opposite.


### PR DESCRIPTION
## Summary
- update Init.server.lua so getEndFacing searches Workspace descendants for the Cameras folder
- ensure server-side spawn orientation uses intro camera parts even when Cameras is nested

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1feb5ac4083329f176b6ef8614730