### PR TITLE
Ensure spawn logic waits for intro cameras

### DIFF
--- a/ServerScriptService/Init.server.lua
+++ b/ServerScriptService/Init.server.lua
@@ -50,14 +50,55 @@ local function findSpawn()
 	return nil
 end
 
+local function findCamerasFolder()
+        local function isCameraContainer(inst)
+                return inst and inst.Name == "Cameras"
+        end
+
+        local direct = Workspace:FindFirstChild("Cameras")
+        if isCameraContainer(direct) then
+                return direct
+        end
+
+        local descendant = Workspace:FindFirstChild("Cameras", true)
+        if isCameraContainer(descendant) then
+                return descendant
+        end
+
+        local deadline = os.clock() + 5
+        local found
+        local conn
+        conn = Workspace.DescendantAdded:Connect(function(inst)
+                if not found and isCameraContainer(inst) then
+                        found = inst
+                end
+        end)
+
+        repeat
+                if found then break end
+                task.wait(0.1)
+                local candidate = Workspace:FindFirstChild("Cameras", true)
+                if isCameraContainer(candidate) then
+                        found = candidate
+                        break
+                end
+        until os.clock() >= deadline
+
+        if conn then
+                conn:Disconnect()
+        end
+
+        return found
+end
+
 local function getEndFacing()
-	local cams = Workspace:FindFirstChild("Cameras")
-	local endPos = cams and cams:FindFirstChild("endPos")
-	if endPos and endPos:IsA("BasePart") then
-		-- Camera looks along endPos.LookVector; to face the camera, use the opposite.
-		return -endPos.CFrame.LookVector
-	end
-	return Vector3.new(0,0,1)
+        local cams = findCamerasFolder()
+        local endPos = cams and cams:FindFirstChild("endPos")
+        if endPos and endPos:IsA("BasePart") then
+                -- Camera looks along endPos.LookVector; to face the camera, use the opposite.
+                return -endPos.CFrame.LookVector
+        end
+        return Vector3.new(0,0,1)
 end
 
 -- Optional: a HumanoidDescription for Ninja (for fallback if there's no model)


### PR DESCRIPTION
## Summary
- update Init.server.lua so getEndFacing searches Workspace descendants for the Cameras folder and waits up to five seconds for it to replicate
- ensure server-side spawn orientation uses intro camera parts even when Cameras is nested or delayed

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1feb5ac4083329f176b6ef8614730