### PR TITLE
Restore camera wait logic when orienting spawned players

### DIFF
--- a/ServerScriptService/Init.server.lua
+++ b/ServerScriptService/Init.server.lua
@@ -99,14 +99,6 @@ local function getEndFacing()
                 return -endPos.CFrame.LookVector
         end
         return Vector3.new(0,0,1)
-local function getEndFacing()
-        local cams = Workspace:FindFirstChild("Cameras", true)
-	local endPos = cams and cams:FindFirstChild("endPos")
-	if endPos and endPos:IsA("BasePart") then
-		-- Camera looks along endPos.LookVector; to face the camera, use the opposite.
-		return -endPos.CFrame.LookVector
-	end
-	return Vector3.new(0,0,1)
 end
 
 -- Optional: a HumanoidDescription for Ninja (for fallback if there's no model)


### PR DESCRIPTION
## Summary
- remove the duplicate `getEndFacing` definition that bypassed the camera lookup helper
- ensure spawned characters still wait for the Cameras folder before choosing a facing direction

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e204efc62483328442aa430d0eb020