### PR TITLE
Ensure intro sequence waits for current camera readiness

### DIFF
--- a/ReplicatedStorage/BootModules/BootUI.lua
+++ b/ReplicatedStorage/BootModules/BootUI.lua
@@ -712,10 +712,23 @@ function BootUI.start(config)
                         return cam
                 end
 
-                local deadline = os.clock() + (timeout or 5)
+                local cameraTimeout = timeout or 5
+
+                local ok, camera = pcall(function()
+                        return Workspace:WaitForChild("Camera", cameraTimeout)
+                end)
+                if ok and camera then
+                        cam = camera
+                        if Workspace.CurrentCamera ~= camera then
+                                Workspace.CurrentCamera = camera
+                        end
+                        return cam
+                end
+
+                local deadline = os.clock() + cameraTimeout
                 repeat
                         task.wait(0.05)
-                        cam = Workspace.CurrentCamera or cam
+                        cam = Workspace.CurrentCamera or cam or Workspace:FindFirstChildOfClass("Camera")
                         if cam then
                                 return cam
                         end


### PR DESCRIPTION
## Summary
- ensure the intro camera sequence waits for the workspace camera to exist before running
- fall back to finding or creating the current camera so the intro plays on initial load

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e21081f8b08332bc4325efa670a61c