### PR TITLE
Ensure ninja persona clones can move

### DIFF
--- a/ServerScriptService/PersonaService.lua
+++ b/ServerScriptService/PersonaService.lua
@@ -167,6 +167,24 @@ local function robustSetCharacter(player, newCharacter)
 	-- 1. Parent to workspace
 	-- 2. Set CFrame before assignment
 	-- 3. Assign to player.Character
+	local function ensureCharacterCanMove(character)
+		-- Some template rigs are stored with anchored parts to display them in Studio.
+		-- Clear anchors and any immobilizing states so movement/jumps work after cloning.
+		for _, descendant in ipairs(character:GetDescendants()) do
+			if descendant:IsA("BasePart") then
+				descendant.Anchored = false
+			end
+		end
+
+		local humanoid = character:FindFirstChildOfClass("Humanoid")
+		if humanoid then
+			humanoid.PlatformStand = false
+			humanoid.Sit = false
+			humanoid:ChangeState(Enum.HumanoidStateType.GettingUp)
+		end
+	end
+
+	ensureCharacterCanMove(newCharacter)
 	newCharacter.Parent = workspace
 	local hrp = newCharacter:FindFirstChild("HumanoidRootPart")
 	if hrp then
@@ -178,6 +196,7 @@ local function robustSetCharacter(player, newCharacter)
 		end
 		hrp.CFrame = spawnCFrame
 	end
+	ensureCharacterCanMove(newCharacter)
 	player.Character = newCharacter
 	-- Attach Animate script for movement animations
 	attachAnimateScript(newCharacter)
@@ -530,4 +549,3 @@ Players.PlayerAdded:Connect(function(player)
 end)
 
 return PersonaService
-


### PR DESCRIPTION
## Summary
- clear anchored parts on cloned persona rigs and reset humanoid states so ninja bodies are not frozen
- keep character replacement flow intact while guaranteeing movement controls work after switching personas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462b146fac8332a1150d2f49b58f98)