### PR TITLE
Fix Ninja intro unfreeze by resetting humanoid state

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/IntroCameraController.lua
+++ b/StarterPlayer/StarterPlayerScripts/IntroCameraController.lua
@@ -102,6 +102,9 @@ local function unfreezeCharacter(character)
         humanoid.JumpHeight = 7
     end
     humanoid.AutoRotate = true
+    humanoid.PlatformStand = false
+    humanoid.Sit = false
+    humanoid:ChangeState(Enum.HumanoidStateType.Running)
 
     -- Unanchor all BaseParts in the character
     local unanchoredCount = 0
@@ -171,4 +174,3 @@ if ReleaseIntroEvent then
 else
     warn("[IntroCameraController] ReleaseIntro RemoteEvent not found!")
 end
-


### PR DESCRIPTION
## Summary
- clear humanoid PlatformStand/Sit and force running state during intro unfreeze so Ninja avatars regain movement

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464365b9988332baa34a15b20aae41)