### PR TITLE
Fix Ninja intro unfreeze by resetting humanoid state

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/IntroCameraController.lua
+++ b/StarterPlayer/StarterPlayerScripts/IntroCameraController.lua
@@ -102,6 +102,8 @@ local function unfreezeCharacter(character)
         humanoid.JumpHeight = 7
     end
     humanoid.AutoRotate = true
+    humanoid.PlatformStand = false
+    humanoid.Sit = false
 
     -- Unanchor all BaseParts in the character
     local unanchoredCount = 0
@@ -113,6 +115,9 @@ local function unfreezeCharacter(character)
             end
         end
     end
+
+    humanoid:ChangeState(Enum.HumanoidStateType.GettingUp)
+    humanoid:ChangeState(Enum.HumanoidStateType.Running)
 
     -- Restore controls
     ContextActionService:UnbindAction("FreezeMovement")
@@ -171,4 +176,3 @@ if ReleaseIntroEvent then
 else
     warn("[IntroCameraController] ReleaseIntro RemoteEvent not found!")
 end
-


### PR DESCRIPTION
## Summary
- adjust unfreeze order so Ninja humanoids are reanchored first, then forced through getting up/running states after release

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464365b9988332baa34a15b20aae41)