### PR TITLE
Add MCP repair script and documentation to fix Roblox Studio mcp.bat

### DIFF
--- a/ROBLOX_STUDIO_MCP.md
+++ b/ROBLOX_STUDIO_MCP.md
@@ -1,0 +1,65 @@
+# Roblox Studio MCP repair
+
+This repo does not need Rojo for the current MCP fix. Rojo is a source-sync/build tool; MCP is the bridge that lets a connected agent talk to Roblox Studio. If the goal is to get Studio MCP working again, focus on the MCP launcher first.
+
+## Problem seen on the PC
+
+Running:
+
+```bat
+cmd /k "%LOCALAPPDATA%\Roblox\mcp.bat"
+```
+
+printed errors like:
+
+```text
+'else' is not recognized as an internal or external command
+'"%B/..\StudioMCP.exe"' is not recognized as an internal or external command
+```
+
+That usually means `%LOCALAPPDATA%\Roblox\mcp.bat` was generated for an older Roblox Studio install or got parsed badly after Studio updated.
+
+## Repair the MCP launcher
+
+On the Windows PC that has Roblox Studio installed, run this from the repo root:
+
+```bat
+tools\fix_roblox_studio_mcp.bat
+```
+
+The repair script searches:
+
+```text
+%LOCALAPPDATA%\Roblox\Versions\
+```
+
+for the newest `StudioMCP.exe`, then rewrites:
+
+```text
+%LOCALAPPDATA%\Roblox\mcp.bat
+```
+
+as a simpler launcher that points directly at the current `StudioMCP.exe`.
+
+## Test it
+
+After the repair, run:
+
+```bat
+cmd /k "%LOCALAPPDATA%\Roblox\mcp.bat"
+```
+
+If it stays open without the old `else` / `%B` errors, reopen Roblox Studio and reconnect the MCP client.
+
+## If it still fails
+
+1. Open Roblox Studio once so it updates its `Versions` folder.
+2. Rerun:
+   ```bat
+   tools\fix_roblox_studio_mcp.bat
+   ```
+3. Test again:
+   ```bat
+   cmd /k "%LOCALAPPDATA%\Roblox\mcp.bat"
+   ```
+4. If it says `StudioMCP.exe` cannot be found, Roblox Studio may need to be updated or reinstalled.

--- a/tools/fix_roblox_studio_mcp.bat
+++ b/tools/fix_roblox_studio_mcp.bat
@@ -1,0 +1,49 @@
+@echo off
+setlocal EnableExtensions
+
+rem Repairs the Roblox Studio MCP launcher at %LOCALAPPDATA%\Roblox\mcp.bat.
+rem The generated launcher avoids fragile IF (...) ELSE (...) parsing so it keeps
+rem working after Roblox Studio updates its version-* folder.
+
+set "ROBLOX_DIR=%LOCALAPPDATA%\Roblox"
+set "VERSIONS_DIR=%ROBLOX_DIR%\Versions"
+set "TARGET=%ROBLOX_DIR%\mcp.bat"
+set "STUDIO_MCP="
+
+if not exist "%VERSIONS_DIR%" goto :missing_versions
+
+for /f "delims=" %%F in ('dir /b /s /a:-d /o:-d "%VERSIONS_DIR%\StudioMCP.exe" 2^>nul') do (
+    set "STUDIO_MCP=%%F"
+    goto :found_studio_mcp
+)
+
+goto :missing_studio_mcp
+
+:found_studio_mcp
+> "%TARGET%" echo @echo off
+>> "%TARGET%" echo setlocal EnableExtensions
+>> "%TARGET%" echo set "STUDIO_MCP=%STUDIO_MCP%"
+>> "%TARGET%" echo if not exist "%%STUDIO_MCP%%" goto :missing_studio_mcp
+>> "%TARGET%" echo "%%STUDIO_MCP%%" %%*
+>> "%TARGET%" echo exit /b %%ERRORLEVEL%%
+>> "%TARGET%" echo :missing_studio_mcp
+>> "%TARGET%" echo echo StudioMCP.exe was not found at "%%STUDIO_MCP%%" 1^>^&2
+>> "%TARGET%" echo echo Open Roblox Studio once, then rerun tools\fix_roblox_studio_mcp.bat from this repo. 1^>^&2
+>> "%TARGET%" echo exit /b 1
+
+echo Repaired "%TARGET%"
+echo Using "%STUDIO_MCP%"
+echo.
+echo Test it with:
+echo   cmd /k "%%LOCALAPPDATA%%\Roblox\mcp.bat"
+exit /b 0
+
+:missing_versions
+echo Could not find Roblox Versions folder: "%VERSIONS_DIR%" 1>&2
+echo Open or reinstall Roblox Studio, then run this repair script again. 1>&2
+exit /b 1
+
+:missing_studio_mcp
+echo Could not find StudioMCP.exe under "%VERSIONS_DIR%" 1>&2
+echo Open/update Roblox Studio, then run this repair script again. 1>&2
+exit /b 1


### PR DESCRIPTION
### Motivation

- Roblox Studio's generated `mcp.bat` can become invalid after Studio updates, producing parsing errors like `'else' is not recognized` and broken `%B` expansions. 
- The intent is to provide a stable, simple launcher that always points to the current `StudioMCP.exe` and avoid fragile conditional parsing in the generated `mcp.bat`.
- Provide a straightforward repair workflow for developers to restore MCP connectivity without touching Rojo or other build tooling.

### Description

- Add `tools/fix_roblox_studio_mcp.bat`, a Windows repair script that searches ` %LOCALAPPDATA%\Roblox\Versions` for the newest `StudioMCP.exe` and rewrites `%LOCALAPPDATA%\Roblox\mcp.bat` to directly invoke that executable.
- The new launcher written by the script uses a simple `if not exist` check and direct invocation to avoid fragile `IF (...) ELSE (...)` parsing problems.
- Add `ROBLOX_STUDIO_MCP.md` with reproduction notes, repair instructions, and basic troubleshooting steps for running the script and validating the fix.
- The script emits clear exit codes and user-facing error messages when the `Versions` folder or `StudioMCP.exe` cannot be found.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4784677758833280a6a4ab830751d4)